### PR TITLE
Add bootup output to reflect that kolide binary is serving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 kolide.exe
 kolide
+kolide-ose*

--- a/config.go
+++ b/config.go
@@ -42,7 +42,7 @@ var defaultMysqlConfigData = mysqlConfigData{
 }
 
 var defaultServerConfigData = serverConfigData{
-	Address: ":8080",
+	Address: "127.0.0.1:8080",
 	Cert:    "./tools/kolide.crt",
 	Key:     "./tools/kolide.key",
 }

--- a/kolide.go
+++ b/kolide.go
@@ -122,6 +122,9 @@ func main() {
 		dropTables(db)
 		createTables(db)
 	case serve.FullCommand():
+		fmt.Printf("=> %s %s application starting on https://%s\n", app.Name, version, config.Server.Address)
+		fmt.Println("=> Run `kolide help serve` for more startup options")
+		fmt.Println("Use Ctrl-C to stop\n\n")
 		CreateServer().RunTLS(
 			config.Server.Address,
 			config.Server.Cert,


### PR DESCRIPTION
Example output:

``` bash
$ kolide-ose serve
=> kolide 0.1.0 application starting on https://:8080
=> Run `kolide help serve` for more startup options
Use Ctrl-C to stop

time="2016-08-02T14:25:02-07:00" level=info msg="some info logs!"
file=proc.go func=runtime.main line=188
time="2016-08-02T14:25:02-07:00" level=error msg="some error logs :("
file=proc.go func=runtime.main line=188
```

close #26
