### PR TITLE
Turn down logging in tests except after failure

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestGenerateVC(t *testing.T) {
-	db := openTestDB()
+	db := openTestDB(t)
 
 	user, err := NewUser(db, "marpaia", "foobar", "mike@kolide.co", true, false)
 	if err != nil {
@@ -42,7 +42,7 @@ func TestGenerateJWT(t *testing.T) {
 }
 
 func TestVC(t *testing.T) {
-	db := openTestDB()
+	db := openTestDB(t)
 	r := createEmptyTestServer(db)
 
 	user, err := NewUser(db, "marpaia", "foobar", "mike@kolide.co", false, false)
@@ -112,7 +112,7 @@ func TestVC(t *testing.T) {
 }
 
 func TestIsUserID(t *testing.T) {
-	db := openTestDB()
+	db := openTestDB(t)
 
 	user1, err := NewUser(db, "marpaia", "foobar", "mike@kolide.co", false, false)
 	if err != nil {
@@ -131,7 +131,7 @@ func TestIsUserID(t *testing.T) {
 }
 
 func TestCanPerformActionsOnUser(t *testing.T) {
-	db := openTestDB()
+	db := openTestDB(t)
 
 	user1, err := NewUser(db, "marpaia", "foobar", "mike@kolide.co", false, false)
 	if err != nil {

--- a/kolide.go
+++ b/kolide.go
@@ -150,7 +150,8 @@ $7777777....$....$777$.....+DI..DDD..DDI...8D...D8......$D:..8D....8D...8D......
 		fmt.Println("=> Run `kolide help serve` for more startup options")
 		fmt.Println("Use Ctrl-C to stop")
 		fmt.Print("\n\n")
-		CreateServer(db).RunTLS(
+
+		CreateServer(db, os.Stderr).RunTLS(
 			config.Server.Address,
 			config.Server.Cert,
 			config.Server.Key)

--- a/models.go
+++ b/models.go
@@ -179,20 +179,6 @@ func openDB(user, password, address, dbName string) (*gorm.DB, error) {
 	return db, nil
 }
 
-func openTestDB() *gorm.DB {
-	db, err := gorm.Open("sqlite3", ":memory:")
-	if err != nil {
-		panic(fmt.Sprintf("Error opening test DB: %s", err.Error()))
-	}
-
-	setDBSettings(db)
-	createTables(db)
-	if db.Error != nil {
-		panic(fmt.Sprintf("Error creating test DB tables: %s", db.Error.Error()))
-	}
-	return db
-}
-
 func dropTables(db *gorm.DB) {
 	for _, table := range tables {
 		db.DropTableIfExists(table)

--- a/sessions_test.go
+++ b/sessions_test.go
@@ -23,7 +23,7 @@ func (w *MockResponseWriter) WriteHeader(int) {
 }
 
 func TestSessionManagerVC(t *testing.T) {
-	db := openTestDB()
+	db := openTestDB(t)
 
 	admin, err := NewUser(db, "admin", "foobar", "admin@kolide.co", true, false)
 	if err != nil {
@@ -74,7 +74,7 @@ func TestSessionManagerVC(t *testing.T) {
 }
 
 func TestSessionCreation(t *testing.T) {
-	db := openTestDB()
+	db := openTestDB(t)
 	r := createEmptyTestServer(db)
 	admin, _ := NewUser(db, "admin", "foobar", "admin@kolide.co", true, false)
 

--- a/users.go
+++ b/users.go
@@ -53,7 +53,6 @@ func NewUser(db *gorm.DB, username, password, email string, admin, needsPassword
 // supplied password with the stored password salt
 func (u *User) ValidatePassword(password string) error {
 	saltAndPass := []byte(fmt.Sprintf("%s%s", password, u.Salt))
-	logrus.Info(string(saltAndPass))
 	return bcrypt.CompareHashAndPassword(u.Password, saltAndPass)
 }
 

--- a/users_test.go
+++ b/users_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestNewUser(t *testing.T) {
-	db := openTestDB()
+	db := openTestDB(t)
 
 	user, err := NewUser(db, "marpaia", "foobar", "mike@kolide.co", true, false)
 	if err != nil {
@@ -34,7 +34,7 @@ func TestNewUser(t *testing.T) {
 }
 
 func TestValidatePassword(t *testing.T) {
-	db := openTestDB()
+	db := openTestDB(t)
 
 	user, err := NewUser(db, "marpaia", "foobar", "mike@kolide.co", true, false)
 	if err != nil {
@@ -57,7 +57,7 @@ func TestValidatePassword(t *testing.T) {
 }
 
 func TestMakeAdmin(t *testing.T) {
-	db := openTestDB()
+	db := openTestDB(t)
 
 	user, err := NewUser(db, "marpaia", "foobar", "mike@kolide.co", false, false)
 	if err != nil {
@@ -91,7 +91,7 @@ func TestMakeAdmin(t *testing.T) {
 }
 
 func TestUpdatingUser(t *testing.T) {
-	db := openTestDB()
+	db := openTestDB(t)
 
 	user, err := NewUser(db, "marpaia", "foobar", "mike@kolide.co", false, false)
 	if err != nil {
@@ -121,7 +121,7 @@ func TestUpdatingUser(t *testing.T) {
 }
 
 func TestDeletingUser(t *testing.T) {
-	db := openTestDB()
+	db := openTestDB(t)
 
 	user, err := NewUser(db, "marpaia", "foobar", "mike@kolide.co", false, false)
 	if err != nil {
@@ -150,7 +150,7 @@ func TestDeletingUser(t *testing.T) {
 }
 
 func TestSetPassword(t *testing.T) {
-	db := openTestDB()
+	db := openTestDB(t)
 
 	user, err := NewUser(db, "marpaia", "foobar", "mike@kolide.co", false, false)
 	if err != nil {


### PR DESCRIPTION
When tests succeed, there is now no logging of DB queries or HTTP
requests. If a test fails, the logs will be output.
