### PR TITLE
Demo validation errors with Gin binding

### DIFF
--- a/server.go
+++ b/server.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"io"
+	"net/http"
 	_ "net/http/pprof"
 	"time"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
 	"github.com/kolide/kolide-ose/sessions"
+	"gopkg.in/go-playground/validator.v8"
 )
 
 // ServerError is a helper which accepts a string error and returns a map in
@@ -44,7 +47,65 @@ func createEmptyTestServer(db *gorm.DB) *gin.Engine {
 	server := gin.New()
 	server.Use(DatabaseMiddleware(db))
 	server.Use(SessionBackendMiddleware)
+	server.Use(Errors("", ""))
 	return server
+}
+
+func ValidationErrorToText(e *validator.FieldError) string {
+	fmt.Printf("%+v\n", e)
+	switch e.Tag {
+	case "required":
+		return fmt.Sprintf("%s is required", e.Field)
+	case "max":
+		return fmt.Sprintf("%s cannot be longer than %s", e.Field, e.Param)
+	case "min":
+		return fmt.Sprintf("%s must be longer than %s", e.Field, e.Param)
+	case "email":
+		return fmt.Sprintf("Invalid email format")
+	case "len":
+		return fmt.Sprintf("%s must be %s characters long", e.Field, e.Param)
+	}
+	return fmt.Sprintf("%s is not valid", e.Field)
+}
+
+// This method collects all errors and submits them to Rollbar
+func Errors(env, token string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Next()
+		// Only run if there are some errors to handle
+		if len(c.Errors) > 0 {
+			for _, e := range c.Errors {
+				// Find out what type of error it is
+				switch e.Type {
+				case gin.ErrorTypePublic:
+					// Only output public errors if nothing has been written yet
+					if !c.Writer.Written() {
+						c.JSON(c.Writer.Status(), gin.H{"Error": e.Error()})
+					}
+				case gin.ErrorTypeBind:
+					errs := e.Err.(validator.ValidationErrors)
+					list := make(map[string]string)
+					for field, err := range errs {
+						list[field] = ValidationErrorToText(err)
+					}
+
+					// Make sure we maintain the preset response status
+					status := http.StatusBadRequest
+					if c.Writer.Status() != http.StatusOK {
+						status = c.Writer.Status()
+					}
+					c.JSON(status, gin.H{"errors": list})
+
+				default:
+				}
+
+			}
+			// If there was no public or bind error, display default 500 message
+			if !c.Writer.Written() {
+				c.JSON(http.StatusInternalServerError, gin.H{"Error": "Server Error"})
+			}
+		}
+	}
 }
 
 // Adapted from https://goo.gl/03Qxiy

--- a/validation_test.go
+++ b/validation_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestValidationFailure(t *testing.T) {
+	r := createEmptyTestServer(nil)
+
+	type Foo struct {
+		Foo string `json:"foo" binding:"required,len=10"`
+		Bar string `json:"bar" binding:"required"`
+	}
+
+	r.POST("/foo", func(c *gin.Context) {
+		var f Foo
+		err := c.BindJSON(&f)
+
+		t.Log(err)
+	})
+
+	buff := new(bytes.Buffer)
+	buff.Write([]byte(`{"foo": "foo", "bar": "bar"}`))
+	req, _ := http.NewRequest("POST", "/foo", buff)
+
+	resp := httptest.NewRecorder()
+	r.ServeHTTP(resp, req)
+
+	if resp.Code == http.StatusOK {
+		t.Error("Binding should have failed")
+	}
+
+	t.Logf("JSON:\n%s", resp.Body.Bytes())
+
+	var res map[string]interface{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &res); err != nil {
+		t.Fatalf("Json parse error: %s", err.Error())
+	}
+
+	t.Error("fail")
+}


### PR DESCRIPTION
For reference, this is what the test prints:

```
&{FieldNamespace:Foo.Foo NameNamespace:Foo Field:Foo Name:Foo Tag:len ActualTag:len Kind:string Type:string Param:10 Value:foo}
--- FAIL: TestValidationFailure (0.00s)
    validation_test.go:25: Key: 'Foo.Foo' Error:Field validation for 'Foo' failed on the 'len' tag
    validation_test.go:39: JSON:
        {"errors":{"Foo.Foo":"Foo must be 10 characters long"}}
    validation_test.go:46: fail
```
