### PR TITLE
New flag to disable banner: --disable-banner

### DIFF
--- a/kolide.go
+++ b/kolide.go
@@ -76,9 +76,9 @@ Available Configurations:
   osquery:
       enroll_secret      (string)  (KOLIDE_OSQUERY_ENROLL_SECRET)
       node_key_size      (int)     (KOLIDE_OSQUERY_NODE_KEY_SIZE)
-  tool:
-      debug              (bool)    (KOLIDE_TOOL_DEBUG)
-      disable_banner     (bool)    (KOLIDE_TOOL_DISABLE_BANNER)
+  logging:
+      debug              (bool)    (KOLIDE_LOGGING_DEBUG)
+      disable_banner     (bool)    (KOLIDE_LOGGING_DISABLE_BANNER)
 `,
 }
 
@@ -117,7 +117,7 @@ the way that the kolide server works.
 			viper.GetInt("smtp.pool_connections"),
 			smtp.PlainAuth("", viper.GetString("smtp.username"), viper.GetString("smtp.password"), smtpHost))
 
-		if !viper.GetBool("tool.disable_banner") {
+		if !viper.GetBool("logging.disable_banner") {
 			fmt.Println(`
 
  .........77777$7$....................... .   .  .  .. .... .. . .. . ..
@@ -277,10 +277,10 @@ func initConfig() {
 	setDefaultConfigValue("osquery.status_log_file", "/tmp/osquery_status")
 	setDefaultConfigValue("osquery.result_log_file", "/tmp/osquery_result")
 
-	setDefaultConfigValue("tool.debug", false)
-	setDefaultConfigValue("tool.disable_banner", false)
+	setDefaultConfigValue("logging.debug", false)
+	setDefaultConfigValue("logging.disable_banner", false)
 
-	if viper.GetBool("tool.debug") {
+	if viper.GetBool("logging.debug") {
 		logrus.SetLevel(logrus.DebugLevel)
 	} else {
 		logrus.SetLevel(logrus.WarnLevel)

--- a/tools/app/kolide.yaml
+++ b/tools/app/kolide.yaml
@@ -7,5 +7,5 @@ osquery:
   enroll_secret: super secure
   result_log_file: /tmp/osquery_result
   status_log_file: /tmp/osquery_status
-tool:
+logging:
   debug: true


### PR DESCRIPTION
Gives you the ability to disable the greeting banner. Useful if you want to collect kolide logs via external log aggregation. 

```
SYSTEM@DESKTOP-SQ7HALB C:\Users\marpaia\go\src\github.com\kolide\kolide-ose
> kolide serve


 .........77777$7$....................... .   .  .  .. .... .. . .. . ..
........$7777777777................. . .... .. .. . . .. . .. .  ..  . .. ....
......?7777777777777........................... . . . . . . ..... ..   .........
.....777777777777777................  ....    .. ... .... .. . . .. .....    .
...$77......77$....7$............... .. . .. ......... .. . .... ..  ....... .
..$777$.....7$....$77......+DI....DD .DD8DDDN...D8... . $D:..8DDDDDD~...DD88DDDD
$7777777....$....$777$.....+DI..DDD..DDI...8D...D8......$D:..8D....8D...8D......
77777777........777777 ....+DD,DDO...DD... DD...D8......$D:..8D....D8. .D8.. ...
77777777........777777.....+DDDDD....DD....DD...D8......$D:..8D....D8...DDDD....
77777777....7....77777$....+DI..DDD..DD....DD...D8......$D:..8D....D8...DD......
.7777777....7$....77777....+DI...OD8.~DD8DDDD...DDDDDD..$D:..8DDDDDD8...DDDDDD88
.$777777....777....777$....................... ....................... .........
.....=$77777777777777............................ ...... ....... ........ ......
...........=7777777I................  ..  . . ..  ... .   .....   .  ....
..... ...........I.................. .  .   . ..   .   .    .   . .. . .  . .


=> Server starting on https://0.0.0.0:8080
=> Run `kolide serve --help` for more startup options
Use Ctrl-C to stop


<Ctrl-C>

SYSTEM@DESKTOP-SQ7HALB C:\Users\marpaia\go\src\github.com\kolide\kolide-ose
> kolide serve # with tool: disable_banner set to true

<Ctrl-C>
SYSTEM@DESKTOP-SQ7HALB C:\Users\marpaia\go\src\github.com\kolide\kolide-ose
>
```
