### PR TITLE
first pass at jwt token Authentication

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -1,9 +1,12 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/dgrijalva/jwt-go/request"
 	kitlog "github.com/go-kit/kit/log"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/gorilla/mux"
@@ -237,7 +240,7 @@ func attachAPIRoutes(router *mux.Router, ctx context.Context, svc kolide.Service
 func MakeHandler(ctx context.Context, svc kolide.Service, logger kitlog.Logger) http.Handler {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerBefore(
-			setViewerContext(svc, logger),
+			setViewerContextT(svc, logger),
 		),
 		kithttp.ServerErrorLogger(logger),
 		kithttp.ServerAfter(
@@ -249,8 +252,9 @@ func MakeHandler(ctx context.Context, svc kolide.Service, logger kitlog.Logger) 
 	attachAPIRoutes(api, ctx, svc, opts)
 
 	r := mux.NewRouter()
-	r.PathPrefix("/api/v1/kolide").Handler(authMiddleware(svc, logger, api))
-	r.Handle("/api/login", login(svc, logger)).Methods("POST")
+	r.PathPrefix("/api/v1/kolide").Handler(authMiddlewareT(svc, logger, api))
+	r.Handle("/api/login", loginT(svc, logger)).Methods("POST")
+	r.Handle("/api/v1/token/refresh", refresh(svc, logger)).Methods("POST")
 	r.Handle("/api/logout", logout(svc, logger)).Methods("GET")
 	r.PathPrefix("/assets").Handler(http.StripPrefix("/assets", http.FileServer(newBinaryFileSystem("/build"))))
 
@@ -273,6 +277,36 @@ func setViewerContext(svc kolide.Service, logger kitlog.Logger) kithttp.RequestF
 		}
 
 		user, err := svc.User(ctx, session.UserID)
+		if err != nil {
+			logger.Log("err", err, "error-source", "setViewerContext")
+			return ctx
+		}
+
+		ctx = context.WithValue(ctx, "viewerContext", &viewerContext{
+			user: user,
+		})
+		logger.Log("msg", "viewer context set", "user", user.ID)
+		// get the user-id for request
+		if strings.Contains(r.URL.Path, "users/") {
+			ctx = withUserIDFromRequest(r, ctx)
+		}
+		return ctx
+	}
+}
+
+func setViewerContextT(svc kolide.Service, logger kitlog.Logger) kithttp.RequestFunc {
+	var (
+		secret = []byte("insecure-jwt-key")
+	)
+	return func(ctx context.Context, r *http.Request) context.Context {
+		claims := &kolideClaims{}
+		_, err := request.ParseFromRequestWithClaims(r, request.AuthorizationHeaderExtractor, claims, func(token *jwt.Token) (interface{}, error) {
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+			}
+			return secret, nil
+		})
+		user, err := svc.User(ctx, claims.UserID)
 		if err != nil {
 			logger.Log("err", err, "error-source", "setViewerContext")
 			return ctx

--- a/server/http_auth_token.go
+++ b/server/http_auth_token.go
@@ -1,0 +1,189 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/dgrijalva/jwt-go/request"
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/kolide/kolide-ose/kolide"
+)
+
+func loginT(svc kolide.Service, logger kitlog.Logger) http.HandlerFunc {
+	// TODO: pass from config
+	var (
+		secret               = []byte("insecure-jwt-key")
+		authTokenDuration    = time.Minute * 30
+		refreshTokenDuration = time.Hour * 24 * 14
+	)
+	ctx := context.Background()
+	return func(w http.ResponseWriter, r *http.Request) {
+		var loginRequest struct {
+			Username *string
+			Password *string
+		}
+		if err := json.NewDecoder(r.Body).Decode(&loginRequest); err != nil {
+			encodeResponse(ctx, w, getUserResponse{
+				Err: err,
+			})
+			logger.Log("err", err)
+			return
+		}
+		var username, password string
+		{
+			if loginRequest.Username != nil {
+				username = *loginRequest.Username
+			}
+			if loginRequest.Password != nil {
+				password = *loginRequest.Password
+			}
+		}
+		// retrieve user or respond with error
+		user, err := svc.Authenticate(ctx, username, password)
+		switch err.(type) {
+		case nil:
+			logger.Log("msg", "authenticated", "user", username, "id", user.ID)
+		case authError:
+			encodeResponse(ctx, w, getUserResponse{
+				Err: err,
+			})
+			logger.Log("err", err, "user", username)
+			return
+		default:
+			encodeResponse(ctx, w, getUserResponse{
+				Err: errors.New("unknown error, try again later"),
+			})
+			logger.Log("err", err, "user", username)
+			return
+		}
+
+		// logged in, give out a token
+		authToken, err := newToken(authTokenDuration, user.ID, secret)
+		if err != nil {
+			encodeResponse(ctx, w, getUserResponse{
+				Err: errors.New("unknown error, try again later"),
+			})
+			logger.Log("err", err, "user", username)
+			return
+		}
+
+		refreshToken, err := newToken(refreshTokenDuration, user.ID, secret)
+		if err != nil {
+			encodeResponse(ctx, w, getUserResponse{
+				Err: errors.New("unknown error, try again later"),
+			})
+			logger.Log("err", err, "user", username)
+			return
+		}
+
+		var jwtLoginResponse = struct {
+			jwtToken
+			getUserResponse
+		}{
+			jwtToken{
+				AuthToken:    authToken,
+				RefreshToken: refreshToken,
+			},
+			getUserResponse{
+				ID:                 user.ID,
+				Username:           user.Username,
+				Name:               user.Name,
+				Admin:              user.Admin,
+				Enabled:            user.Enabled,
+				NeedsPasswordReset: user.NeedsPasswordReset,
+			},
+		}
+
+		encodeResponse(ctx, w, jwtLoginResponse)
+
+	}
+}
+
+func refresh(svc kolide.Service, logger kitlog.Logger) http.HandlerFunc {
+	var (
+		secret            = []byte("insecure-jwt-key")
+		authTokenDuration = time.Minute * 30
+	)
+	ctx := context.Background()
+	return func(w http.ResponseWriter, r *http.Request) {
+		token, claims, err := tokenFromRequest(r, secret)
+		if err != nil || !token.Valid {
+			http.Error(w, "authentication failed", http.StatusUnauthorized)
+			logger.Log("err", err)
+			return
+		}
+		authToken, err := newToken(authTokenDuration, claims.UserID, secret)
+		if err != nil {
+			encodeResponse(ctx, w, getUserResponse{
+				Err: errors.New("unknown error, try again later"),
+			})
+			logger.Log("err", err)
+			return
+		}
+
+		encodeResponse(ctx, w, jwtToken{AuthToken: authToken})
+	}
+}
+
+func authMiddlewareT(svc kolide.Service, logger kitlog.Logger, next http.Handler) http.Handler {
+	var (
+		secret = []byte("insecure-jwt-key")
+	)
+	logger = kitlog.NewContext(logger).With("method", "authMiddleware")
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token, err := request.ParseFromRequest(r, request.AuthorizationHeaderExtractor, func(token *jwt.Token) (interface{}, error) {
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+			}
+			return secret, nil
+		})
+		if err != nil || !token.Valid {
+			http.Error(w, "authentication failed", http.StatusUnauthorized)
+			logger.Log("err", err)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func tokenFromRequest(r *http.Request, secret []byte) (*jwt.Token, *kolideClaims, error) {
+	claims := &kolideClaims{}
+	token, err := request.ParseFromRequestWithClaims(r, request.AuthorizationHeaderExtractor, claims, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+		}
+		return secret, nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return token, claims, nil
+}
+
+type jwtToken struct {
+	AuthToken    string `json:"auth_token"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+}
+
+type kolideClaims struct {
+	UserID uint `json:"user_id"`
+	jwt.StandardClaims
+}
+
+func newToken(duration time.Duration, userID uint, secret []byte) (string, error) {
+	claims := kolideClaims{
+		userID,
+		jwt.StandardClaims{
+			IssuedAt:  time.Now().Unix(),
+			ExpiresAt: time.Now().Add(duration).Unix(),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(secret)
+}


### PR DESCRIPTION
The Go code is a bit messy, I can clean it up. Looking for feedback on authentication request/response below from @marpaia and @mikestone14 

Endpoints: 

```
/api/v1/login
/api/v1/token/refresh
```

Flow:
The user logins, the server sends back two tokens:
`auth_token`: (short lived,~30 min). Used to authenticate every API call
`refresh_token`: (long lived, ?two weeks? checked against DB?). Used to get a new auth token.

```
# /api/v1/login request
curl -X "POST" "http://127.0.0.1:8080/api/login" \
    -H "Content-Type: application/json; charset=utf-8" \
    -d "{\"username\":\"admin\",\"password\":\"secret\"}"

# /api/v1/login respose:
200 OK
{
  "auth_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzMxOTkxNTYsImlhdCI6MTQ3MzE5NzM1Nn0.2LyX-V2QvTaDFrCtdUnqhfbZSljqNmZpynVHkBLS6K8",
  "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzQ0MDY5NTYsImlhdCI6MTQ3MzE5NzM1Nn0._NqKm21sZVQIx-3hbhKt-MsyYFbWT7lJ7JhKI5jz7OM",
  "id": 1,
  "username": "admin",
  "email": "",
  "name": "",
  "admin": true,
  "enabled": true,
  "needs_password_reset": false
}

```

```
# /api/v1/token/refresh request 
# the Authorization: Bearer header holds the refresh token 
curl -X "POST" "http://127.0.0.1:8080/api/v1/token/refresh" \
    -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzQ0MDY5NTYsImlhdCI6MTQ3MzE5NzM1Nn0._NqKm21sZVQIx-3hbhKt-MsyYFbWT7lJ7JhKI5jz7OM" \
    -H "Content-Type: application/json; charset=utf-8" \
    -d "{}"

# /api/v1/token/refresh response
200 OK
{"auth_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxLCJleHAiOjE0NzMyMDQzMjIsImlhdCI6MTQ3MzIwMjUyMn0.uf4MCpfePOkvcd-8O_1Z2jrRofM2XALWquoAvu-XkMU"}
```

Does the above look ok? Any concerns/questions?
