### PR TITLE
move serving static assets outside of the API handler

### DIFF
--- a/cli/serve.go
+++ b/cli/serve.go
@@ -79,7 +79,9 @@ the way that the kolide server works.
 		httpLogger := kitlog.NewContext(logger).With("component", "http")
 
 		apiHandler := server.MakeHandler(ctx, svc, httpLogger)
-		http.Handle("/", accessControl(apiHandler))
+		http.Handle("/api", accessControl(apiHandler))
+		http.Handle("/assets/", server.ServeStaticAssets("/assets/"))
+		http.Handle("/", server.ServeFrontend())
 
 		errs := make(chan error, 2)
 		go func() {

--- a/server/frontend.go
+++ b/server/frontend.go
@@ -1,16 +1,13 @@
 package server
 
 import (
+	"fmt"
 	"html/template"
 	"net/http"
 	"strings"
 
 	assetfs "github.com/elazarl/go-bindata-assetfs"
 )
-
-var frontendRoutes = [...]string{
-	"/",
-}
 
 type binaryFileSystem struct {
 	fs *assetfs.AssetFS
@@ -41,11 +38,18 @@ func newBinaryFileSystem(root string) *binaryFileSystem {
 	}
 }
 
-func serveReactApp(w http.ResponseWriter, r *http.Request) {
-	t, err := template.ParseFiles("frontend/templates/react.tmpl")
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-	t.Execute(w, nil)
+func ServeFrontend() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t, err := template.ParseFiles("frontend/templates/react.tmpl")
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		err = t.Execute(w, nil)
+		fmt.Println(err)
+	})
+}
+
+func ServeStaticAssets(path string) http.Handler {
+	return http.StripPrefix(path, http.FileServer(newBinaryFileSystem("/build")))
 }

--- a/server/handler.go
+++ b/server/handler.go
@@ -252,11 +252,6 @@ func MakeHandler(ctx context.Context, svc kolide.Service, logger kitlog.Logger) 
 	r.PathPrefix("/api/v1/kolide").Handler(authMiddleware(svc, logger, api))
 	r.Handle("/api/login", login(svc, logger)).Methods("POST")
 	r.Handle("/api/logout", logout(svc, logger)).Methods("GET")
-	r.PathPrefix("/assets").Handler(http.StripPrefix("/assets", http.FileServer(newBinaryFileSystem("/build"))))
-
-	for _, route := range frontendRoutes {
-		r.HandleFunc(route, serveReactApp)
-	}
 
 	return r
 }


### PR DESCRIPTION
This PR moves previous ServeReactApp, and ServeStaticAssets handlers outside of the API router.
The change allows the react app to have it's own routing logic. 
Now the sever directs all requests to `/` to the react app, but routes `/api` and other server routes on it's own. 

I also found it made more sense to have `/api` routes separate from `/`, `/assets` semantically. 
