### PR TITLE
Only attempt to parse config file if it is specified by flag

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -46,7 +46,7 @@ wish to override the default value.
 `,
 	}
 
-	rootCmd.PersistentFlags().String("config", "", "Path to a configuration file")
+	rootCmd.PersistentFlags().StringP("config", "c", "", "Path to a configuration file")
 
 	return rootCmd
 }

--- a/config/config.go
+++ b/config/config.go
@@ -323,19 +323,17 @@ func (man Manager) getConfigDuration(key string) time.Duration {
 
 // loadConfigFile handles the loading of the config file.
 func (man Manager) loadConfigFile() {
-	configFile := man.command.PersistentFlags().Lookup("config").Value.String()
-	if configFile != "" {
-		man.viper.SetConfigFile(configFile)
-	} else {
-		man.viper.SetConfigName("kolide")
-		man.viper.AddConfigPath(".")
-		man.viper.AddConfigPath("$HOME")
-		man.viper.AddConfigPath("./tools/app")
-		man.viper.AddConfigPath("/etc/kolide")
-	}
-
 	man.viper.SetConfigType("yaml")
 
+	configFile := man.command.PersistentFlags().Lookup("config").Value.String()
+
+	if configFile == "" {
+		// No config file set, only use configs from env
+		// vars/flags/defaults
+		return
+	}
+
+	man.viper.SetConfigFile(configFile)
 	err := man.viper.ReadInConfig()
 
 	fmt.Println("Using config file: ", man.viper.ConfigFileUsed())
@@ -343,7 +341,6 @@ func (man Manager) loadConfigFile() {
 	if err != nil {
 		panic("Error reading config: " + err.Error())
 	}
-
 }
 
 // TestConfig returns a barebones configuration suitable for use in tests.


### PR DESCRIPTION
Previously, the behavior was to search for the config file in a variety of
locations. Now we only attempt to load a config file if it has been explicitly
specified with `-c` or `--config`.

Fixes #165.
