### PR TITLE
Fixes multiple logos on login successful page

### DIFF
--- a/frontend/pages/LoginSuccessfulPage/LoginSuccessfulPage.jsx
+++ b/frontend/pages/LoginSuccessfulPage/LoginSuccessfulPage.jsx
@@ -1,32 +1,17 @@
-import React, { Component, PropTypes } from 'react';
-import { connect } from 'react-redux';
+import React from 'react';
 import componentStyles from './styles';
 import Icon from '../../components/icons/Icon';
-import { removeBackground } from '../../utilities/backgroundImage';
 
-export class LoginSuccessfulPage extends Component {
-  static propTypes = {
-    dispatch: PropTypes.func,
-  };
+const LoginSuccessfulPage = () => {
+  const { loginSuccessStyles, subtextStyles, whiteBoxStyles } = componentStyles;
 
-  componentWillUnmount () {
-    removeBackground();
-  }
+  return (
+    <div style={whiteBoxStyles}>
+      <Icon name="check" />
+      <p style={loginSuccessStyles}>Login successful</p>
+      <p style={subtextStyles}>Hold on to your butts.</p>
+    </div>
+  );
+};
 
-  render () {
-    const { containerStyles, loginSuccessStyles, subtextStyles, whiteBoxStyles } = componentStyles;
-
-    return (
-      <div style={containerStyles}>
-        <img alt="Kolide text logo" src="/assets/images/kolide-logo-text.svg" />
-        <div style={whiteBoxStyles}>
-          <Icon name="check" />
-          <p style={loginSuccessStyles}>Login successful</p>
-          <p style={subtextStyles}>Hold on to your butts.</p>
-        </div>
-      </div>
-    );
-  }
-}
-
-export default connect()(LoginSuccessfulPage);
+export default LoginSuccessfulPage;

--- a/frontend/pages/LoginSuccessfulPage/styles.js
+++ b/frontend/pages/LoginSuccessfulPage/styles.js
@@ -3,10 +3,6 @@ import styles from '../../styles';
 const { color, font, padding } = styles;
 
 export default {
-  containerStyles: {
-    paddingTop: '100px',
-    textAlign: 'center',
-  },
   loginSuccessStyles: {
     color: color.green,
     textTransform: 'uppercase',
@@ -20,11 +16,15 @@ export default {
   },
   whiteBoxStyles: {
     backgroundColor: color.white,
-    margin: '0 auto',
     boxShadow: '0 5px 30px 0 rgba(0,0,0,0.30)',
     borderRadius: '4px',
+    marginBottom: '0px',
+    marginLeft: 'auto',
+    marginRight: 'auto',
     marginTop: padding.base,
-    padding: padding.base,
+    paddingBottom: padding.base,
+    paddingLeft: padding.base,
+    paddingRight: padding.base,
     paddingTop: padding.most,
     textAlign: 'center',
     width: '384px',


### PR DESCRIPTION
I made some changes to how these authentication routes worked which caused the login successful page to display the Kolide text logo twice. This PR fixes it. I also made some style changes to deal with Radium warnings in the console.
### BEFORE:

<img width="533" alt="screen shot 2016-09-15 at 10 44 12 am" src="https://cloud.githubusercontent.com/assets/2905145/18557473/1be3a3b2-7b3d-11e6-8422-f547750cfeae.png">
### AFTER:

<img width="600" alt="screen shot 2016-09-15 at 12 06 55 pm" src="https://cloud.githubusercontent.com/assets/2905145/18557482/2649b65c-7b3d-11e6-82fe-d928d09795aa.png">
