### PR TITLE
nicer validation errors

### DIFF
--- a/server/service_users_test.go
+++ b/server/service_users_test.go
@@ -128,7 +128,7 @@ func TestCreateUser(t *testing.T) {
 		{
 			Username: stringPtr("admin1"),
 			Password: stringPtr("foobar"),
-			wantErr:  invalidArgumentError{field: "email", required: true},
+			wantErr:  invalidArgumentError{invalidArgument{name: "email", reason: "missing required argument"}},
 		},
 		{
 			Username:           stringPtr("admin1"),
@@ -151,7 +151,7 @@ func TestCreateUser(t *testing.T) {
 			Email:              stringPtr("admin1@example.com"),
 			NeedsPasswordReset: boolPtr(true),
 			Admin:              boolPtr(false),
-			wantErr:            invalidArgumentError{field: "username", required: true},
+			wantErr:            invalidArgumentError{invalidArgument{name: "username", reason: "'@' character not allowed in usernames"}},
 		},
 	}
 
@@ -204,11 +204,11 @@ func TestChangeUserPassword(t *testing.T) {
 		},
 		{ // missing token
 			newPassword: "123cat!",
-			wantErr:     invalidArgumentError{field: "token", required: true},
+			wantErr:     invalidArgumentError{invalidArgument{name: "token", reason: "cannot be empty field"}},
 		},
 		{ // missing password
 			token:   "abcd",
-			wantErr: invalidArgumentError{field: "password", required: true},
+			wantErr: invalidArgumentError{invalidArgument{name: "new_password", reason: "cannot be empty field"}},
 		},
 	}
 

--- a/server/validation_users.go
+++ b/server/validation_users.go
@@ -12,36 +12,56 @@ type validationMiddleware struct {
 }
 
 func (mw validationMiddleware) NewUser(ctx context.Context, p kolide.UserPayload) (*kolide.User, error) {
+	var invalid []invalidArgument
 	if p.Username == nil {
-		return nil, invalidArgumentError{field: "username", required: true}
+		invalid = append(invalid, invalidArgument{name: "username", reason: "missing required argument"})
 	}
-
 	if p.Username != nil {
 		if strings.Contains(*p.Username, "@") {
-			// TODO @groob this makes it obvious that the
-			// validation error needs a "reason" field
-			return nil, invalidArgumentError{field: "username", required: true}
+			invalid = append(invalid, invalidArgument{name: "username", reason: "'@' character not allowed in usernames"})
 		}
 	}
-
 	if p.Password == nil {
-		return nil, invalidArgumentError{field: "password", required: true}
+		invalid = append(invalid, invalidArgument{name: "password", reason: "missing required argument"})
 	}
-
 	if p.Email == nil {
-		return nil, invalidArgumentError{field: "email", required: true}
+		invalid = append(invalid, invalidArgument{name: "email", reason: "missing required argument"})
 	}
-
+	if len(invalid) != 0 {
+		return nil, invalidArgumentError(invalid)
+	}
 	return mw.Service.NewUser(ctx, p)
 }
 
 func (mw validationMiddleware) ResetPassword(ctx context.Context, token, password string) error {
+	var invalid []invalidArgument
 	if token == "" {
-		return invalidArgumentError{field: "token", required: true}
+		invalid = append(invalid, invalidArgument{name: "token", reason: "cannot be empty field"})
 	}
-
 	if password == "" {
-		return invalidArgumentError{field: "password", required: true}
+		invalid = append(invalid, invalidArgument{name: "new_password", reason: "cannot be empty field"})
+	}
+	if len(invalid) != 0 {
+		return invalidArgumentError(invalid)
 	}
 	return mw.Service.ResetPassword(ctx, token, password)
+}
+
+type invalidArgumentError []invalidArgument
+type invalidArgument struct {
+	name   string
+	reason string
+}
+
+// invalidArgumentError is returned when one or more arguments are invalid.
+func (e invalidArgumentError) Error() string {
+	return "validation failed"
+}
+
+func (e invalidArgumentError) Invalid() []map[string]string {
+	var invalid []map[string]string
+	for _, i := range e {
+		invalid = append(invalid, map[string]string{"name": i.name, "reason": i.reason})
+	}
+	return invalid
 }


### PR DESCRIPTION
All validation errors now return the format below, matching the `name` of the field and a `reason` why request failed. 

Note: at the moment, not everything is validated. 

```
HTTP/1.1 422 Unprocessable Entity
Date: Fri, 16 Sep 2016 14:10:38 GMT
Content-Length: 138
Connection: close

{
  "message": "Validation Failed",
  "errors": [
    {
      "name": "password",
      "reason": "missing required argument"
    }
  ]
}
```
