### PR TITLE
Forbidden error

### DIFF
--- a/server/endpoint_middleware_test.go
+++ b/server/endpoint_middleware_test.go
@@ -53,7 +53,7 @@ func TestEndpointPermissions(t *testing.T) {
 		{
 			endpoint: mustBeAdmin(e),
 			vc:       &viewerContext{user: user1},
-			wantErr:  forbiddenError{message: "must be an admin"},
+			wantErr:  permissionError{message: "must be an admin"},
 		},
 		{
 			endpoint: canModifyUser(e),
@@ -62,13 +62,13 @@ func TestEndpointPermissions(t *testing.T) {
 		{
 			endpoint: canModifyUser(e),
 			vc:       &viewerContext{user: user1},
-			wantErr:  forbiddenError{message: "no write permissions on user"},
+			wantErr:  permissionError{message: "no write permissions on user"},
 		},
 		{
 			endpoint:  canModifyUser(e),
 			vc:        &viewerContext{user: user1},
 			requestID: admin1.ID,
-			wantErr:   forbiddenError{message: "no write permissions on user"},
+			wantErr:   permissionError{message: "no write permissions on user"},
 		},
 		{
 			endpoint:  canReadUser(e),
@@ -79,7 +79,7 @@ func TestEndpointPermissions(t *testing.T) {
 			endpoint:  canReadUser(e),
 			vc:        &viewerContext{user: user2},
 			requestID: admin1.ID,
-			wantErr:   forbiddenError{message: "no read permissions on user"},
+			wantErr:   permissionError{message: "no read permissions on user"},
 		},
 		{
 			endpoint: validateModifyUserRequest(e),
@@ -90,7 +90,7 @@ func TestEndpointPermissions(t *testing.T) {
 			endpoint: validateModifyUserRequest(e),
 			request:  modifyUserRequest{payload: kolide.UserPayload{Enabled: boolPtr(true)}},
 			vc:       &viewerContext{user: user1},
-			wantErr:  forbiddenError{message: "must be an admin"},
+			wantErr:  permissionError{message: "unauthorized: must be an admin"},
 		},
 	}
 
@@ -112,9 +112,9 @@ func TestEndpointPermissions(t *testing.T) {
 				request = req
 			}
 			_, eerr := tt.endpoint(ctx, request)
-			assert.IsType(t, tt.wantErr, eerr)
-			if ferr, ok := eerr.(forbiddenError); ok {
-				assert.Equal(t, tt.wantErr.(forbiddenError).message, ferr.message)
+			assert.IsType(st, tt.wantErr, eerr)
+			if ferr, ok := eerr.(permissionError); ok {
+				assert.Equal(st, tt.wantErr.(permissionError).message, ferr.Error())
 			}
 		})
 	}

--- a/server/handler.go
+++ b/server/handler.go
@@ -299,6 +299,7 @@ func MakeHandler(ctx context.Context, svc kolide.Service, jwtKey string, ds koli
 			setViewerContext(svc, ds, jwtKey, logger),
 		),
 		kithttp.ServerErrorLogger(logger),
+		kithttp.ServerErrorEncoder(encodeError),
 		kithttp.ServerAfter(
 			kithttp.SetContentType("application/json; charset=utf-8"),
 		),

--- a/server/http_auth.go
+++ b/server/http_auth.go
@@ -30,20 +30,48 @@ func (e authError) AuthError() string {
 	if e.clientReason != "" {
 		return e.clientReason
 	}
-	return "authorization error"
+	return "authentication error"
 }
 
-// forbidden, set when user is authenticated, but not allowd to perform action
-type forbiddenError struct {
+// permissionError, set when user is authenticated, but not allowed to perform action
+type permissionError struct {
 	message string
-	fields  []string
+	badArgs []invalidArgument
 }
 
-func (e forbiddenError) Error() string {
+func (e permissionError) Error() string {
+	switch len(e.badArgs) {
+	case 0:
+	case 1:
+		e.message = fmt.Sprintf("unauthorized: %s",
+			e.badArgs[0].reason,
+		)
+	default:
+		e.message = fmt.Sprintf("unauthorized: %s and %d other errors",
+			e.badArgs[0].reason,
+			len(e.badArgs),
+		)
+	}
 	if e.message == "" {
 		return "unauthorized"
 	}
-	return fmt.Sprintf("unauthorized: %s", e.message)
+	return e.message
+}
+
+func (e permissionError) PermissionError() []map[string]string {
+	var forbidden []map[string]string
+	if len(e.badArgs) == 0 {
+		forbidden = append(forbidden, map[string]string{"reason": e.Error()})
+		return forbidden
+	}
+	for _, arg := range e.badArgs {
+		forbidden = append(forbidden, map[string]string{
+			"name":   arg.name,
+			"reason": arg.reason,
+		})
+	}
+	return forbidden
+
 }
 
 // ViewerContext is a struct which represents the ability for an execution

--- a/server/service_sessions.go
+++ b/server/service_sessions.go
@@ -21,7 +21,7 @@ func (svc service) Login(ctx context.Context, username, password string) (*kolid
 		return nil, "", err
 	}
 	if !user.Enabled {
-		return nil, "", authError{reason: "account disabled"}
+		return nil, "", authError{reason: "account disabled", clientReason: "account disabled"}
 	}
 	if err := user.ValidatePassword(password); err != nil {
 		return nil, "", authError{reason: "bad password", clientReason: "bad credentials"}

--- a/server/service_users.go
+++ b/server/service_users.go
@@ -98,7 +98,7 @@ func (svc service) AuthenticatedUser(ctx context.Context) (*kolide.User, error) 
 		return nil, err
 	}
 	if !vc.IsLoggedIn() {
-		return nil, forbiddenError{}
+		return nil, permissionError{}
 	}
 	return vc.user, nil
 }

--- a/server/transport.go
+++ b/server/transport.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/gorilla/mux"
-	"github.com/kolide/kolide-ose/datastore"
 	"golang.org/x/net/context"
 )
 
@@ -34,78 +33,10 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response interfa
 	return enc.Encode(response)
 }
 
-// erroer interface is implemented by response structs to encode business logic errors
-type errorer interface {
-	error() error
-}
-
 // statuser allows response types to implement a custom
 // http success status - default is 200 OK
 type statuser interface {
 	status() int
-}
-
-// encode errors from business-logic
-func encodeError(_ context.Context, err error, w http.ResponseWriter) {
-	switch err {
-	case datastore.ErrNotFound:
-		w.WriteHeader(http.StatusNotFound)
-	case datastore.ErrExists:
-		w.WriteHeader(http.StatusConflict)
-	default:
-		w.WriteHeader(typeErrsStatus(err))
-	}
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-
-	// decide on error type and encode proper JSON format
-	type validator interface {
-		Invalid() []map[string]string
-	}
-	if e, ok := err.(validator); ok {
-		var ve = struct {
-			Message string              `json:"message"`
-			Errors  []map[string]string `json:"errors"`
-		}{
-			Message: "Validation Failed",
-			Errors:  e.Invalid(),
-		}
-		enc.Encode(ve)
-		return
-	}
-
-	type authenticationError interface {
-		AuthError() string
-	}
-	if e, ok := err.(authenticationError); ok {
-		var ae = struct {
-			Message string `json:"message"`
-			Error   string `json:"error"`
-		}{
-			Message: "Authentication Failed",
-			Error:   e.AuthError(),
-		}
-		enc.Encode(ae)
-		return
-	}
-
-	// other errors
-	enc.Encode(map[string]interface{}{
-		"error": err.Error(),
-	})
-}
-
-func typeErrsStatus(err error) int {
-	switch err.(type) {
-	case invalidArgumentError:
-		return http.StatusUnprocessableEntity
-	case authError:
-		return http.StatusUnauthorized
-	case forbiddenError:
-		return http.StatusForbidden
-	default:
-		return http.StatusInternalServerError
-	}
 }
 
 func idFromRequest(r *http.Request, name string) (uint, error) {

--- a/server/transport_error.go
+++ b/server/transport_error.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/kolide/kolide-ose/datastore"
+	"golang.org/x/net/context"
+)
+
+// erroer interface is implemented by response structs to encode business logic errors
+type errorer interface {
+	error() error
+}
+
+type jsonError struct {
+	Message string              `json:"message"`
+	Errors  []map[string]string `json:"errors,omitempty"`
+	Error   string              `json:"error,omitempty"`
+}
+
+// encode error and status header to the client
+func encodeError(ctx context.Context, err error, w http.ResponseWriter) {
+	// Unwrap Go-Kit Error
+	domain := "service"
+	if e, ok := err.(kithttp.Error); ok {
+		err = e.Err
+		domain = e.Domain
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+
+	type validationError interface {
+		Invalid() []map[string]string
+	}
+	if e, ok := err.(validationError); ok {
+		ve := jsonError{
+			Message: "Validation Failed",
+			Errors:  e.Invalid(),
+		}
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		enc.Encode(ve)
+		return
+	}
+
+	type authenticationError interface {
+		AuthError() string
+	}
+	if e, ok := err.(authenticationError); ok {
+		ae := jsonError{
+			Message: "Authentication Failed",
+			Error:   e.AuthError(),
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		enc.Encode(ae)
+		return
+	}
+
+	type permissionError interface {
+		PermissionError() []map[string]string
+	}
+	if e, ok := err.(permissionError); ok {
+		pe := jsonError{
+			Message: "Permission Denied",
+			Errors:  e.PermissionError(),
+		}
+		w.WriteHeader(http.StatusForbidden)
+		enc.Encode(pe)
+		return
+	}
+
+	// Other errors
+	switch domain {
+	case "service":
+		w.WriteHeader(codeFromErr(err))
+	case kithttp.DomainDecode:
+		w.WriteHeader(http.StatusBadRequest)
+	case kithttp.DomainDo:
+		w.WriteHeader(http.StatusServiceUnavailable)
+	default:
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+	enc.Encode(map[string]interface{}{
+		"error": err.Error(),
+	})
+}
+
+func codeFromErr(err error) int {
+	switch err {
+	case datastore.ErrNotFound:
+		return http.StatusNotFound
+	case datastore.ErrExists:
+		return http.StatusConflict
+	default:
+		return http.StatusInternalServerError
+	}
+}

--- a/server/validation_users.go
+++ b/server/validation_users.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/kolide/kolide-ose/kolide"
@@ -55,7 +56,15 @@ type invalidArgument struct {
 
 // invalidArgumentError is returned when one or more arguments are invalid.
 func (e invalidArgumentError) Error() string {
-	return "validation failed"
+	switch len(e) {
+	case 0:
+		return "validation failed"
+	case 1:
+		return fmt.Sprintf("validation failed: %s %s", e[0].name, e[0].reason)
+	default:
+		return fmt.Sprintf("validation failed: %s %s and %d other errors", e[0].name, e[0].reason,
+			len(e))
+	}
 }
 
 func (e invalidArgumentError) Invalid() []map[string]string {


### PR DESCRIPTION
This code is getting pretty ugly, I'll have to find a better way. 

The biggest issue right now, is that on a PATCH request, there could be multiple fields that are denied for different reasons. Validation errors have a similar issue. 
Typically, you want to bail right away if an error occurs,  and when we log that error it's fine. 
Here, I want to validate the whole input and build up a list of failed properties and reasons. 

Maybe I'm not thinking about it the right way. 

JSON output

```
{
  "message": "Permission Denied",
  "errors": [
    {
      "name": "enabled",
      "reason": "must be an admin"
    },
    {
      "name": "email",
      "reason": "no write permissions on user"
    }
  ]
}
```
