### PR TITLE
Removing underscored import of config from main

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/kolide/kolide-ose/cli"
-	_ "github.com/kolide/kolide-ose/config"
 )
 
 func init() {


### PR DESCRIPTION
This should no longer be necessary.
