### PR TITLE
export PATH in a slightly different way on OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 .PHONY: build
 
 export PATH := $(GOPATH)/bin:$(shell npm bin):$(PATH)
+ifeq ($(shell uname), Darwin)
+SHELL=/bin/bash
+PATH := $(GOPATH)/bin:$(shell npm bin):$(PATH)
+endif
 
 ifeq ($(OS), Windows_NT)
 	OUTPUT = build/kolide.exe


### PR DESCRIPTION
#197 broke the makefile on OS X

the `export PATH` directive doesn't work on OS X unless you also set the shell
