### PR TITLE
Make utility to run server in dev mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,8 @@ define HELP_TEXT
 	make lint-go      - Run the Go linters
 	make lint-js      - Run the JavaScript linters
 
+	make run          - Run the Kolide server in dev mode
+
 endef
 
 help:
@@ -123,6 +125,9 @@ else
 	rm -rf build vendor
 	rm -f assets/bundle.js
 endif
+
+run:
+	$(OUTPUT) serve --dev
 
 docker-build-circle:
 	@echo ">> building docker image"

--- a/README.md
+++ b/README.md
@@ -289,3 +289,10 @@ etc. If you're demo-ing Kolide or testing a quick feature, dev mode is ideal.
 Keep in mind that, since everything is in-memory, when you kill the process,
 everything you did in dev mode will be lost. This is nice for development but
 not so nice for production environments.
+
+If you've used `make build` to build the Kolide binary, you can also run the
+following to launch an in-memory instance of the server:
+
+```
+make run
+```


### PR DESCRIPTION
Often when I'm building, I'll do the following:

```
make generate
make build
./build/kolide.exe serve --dev
```

It would be nicer if I could just use make to run the dev server instead
of having to type out the full path every time:

```
make generate
make build
make run
```
