### PR TITLE
Make datastore migrations explicit

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -47,9 +47,6 @@ func New(driver, conn string, opts ...DBOption) (kolide.Datastore, error) {
 			db.SetLogger(opt.logger)
 			db.LogMode(opt.debug)
 		}
-		if err := ds.Migrate(); err != nil {
-			return nil, err
-		}
 		return ds, nil
 	case "gorm-sqlite3":
 		db, err := openGORM("sqlite3", conn, opt.maxAttempts)
@@ -64,9 +61,6 @@ func New(driver, conn string, opts ...DBOption) (kolide.Datastore, error) {
 		if opt.logger != nil {
 			db.SetLogger(opt.logger)
 			db.LogMode(opt.debug)
-		}
-		if err := ds.Migrate(); err != nil {
-			return nil, err
 		}
 		return ds, nil
 	case "inmem":

--- a/server/service_hosts_test.go
+++ b/server/service_hosts_test.go
@@ -6,12 +6,12 @@ import (
 	"github.com/kolide/kolide-ose/datastore"
 	"github.com/kolide/kolide-ose/kolide"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 
 func TestGetAllHosts(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)
@@ -33,8 +33,7 @@ func TestGetAllHosts(t *testing.T) {
 }
 
 func TestGetHost(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)
@@ -54,8 +53,7 @@ func TestGetHost(t *testing.T) {
 }
 
 func TestNewHost(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)
@@ -75,8 +73,7 @@ func TestNewHost(t *testing.T) {
 }
 
 func TestModifyHost(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)
@@ -100,8 +97,7 @@ func TestModifyHost(t *testing.T) {
 }
 
 func TestDeleteHost(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)
@@ -121,4 +117,13 @@ func TestDeleteHost(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, hosts, 0)
 
+}
+
+func setup(t *testing.T) kolide.Datastore {
+	ds, err := datastore.New("gorm-sqlite3", ":memory:")
+	require.Nil(t, err)
+
+	err = ds.Migrate()
+	require.Nil(t, err)
+	return ds
 }

--- a/server/service_osquery_test.go
+++ b/server/service_osquery_test.go
@@ -7,15 +7,13 @@ import (
 	"time"
 
 	"github.com/WatchBeam/clock"
-	"github.com/kolide/kolide-ose/datastore"
 	"github.com/kolide/kolide-ose/kolide"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestEnrollAgent(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)
@@ -36,8 +34,7 @@ func TestEnrollAgent(t *testing.T) {
 }
 
 func TestEnrollAgentIncorrectEnrollSecret(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)
@@ -83,8 +80,7 @@ func TestHostDetailQueries(t *testing.T) {
 }
 
 func TestGetDistributedQueries(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	mockClock := clock.NewMockClock()
 

--- a/server/service_packs_test.go
+++ b/server/service_packs_test.go
@@ -3,15 +3,13 @@ package server
 import (
 	"testing"
 
-	"github.com/kolide/kolide-ose/datastore"
 	"github.com/kolide/kolide-ose/kolide"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
 
 func TestGetAllPacks(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)
@@ -33,8 +31,7 @@ func TestGetAllPacks(t *testing.T) {
 }
 
 func TestGetPack(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)
@@ -55,8 +52,7 @@ func TestGetPack(t *testing.T) {
 }
 
 func TestNewPack(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)
@@ -76,8 +72,7 @@ func TestNewPack(t *testing.T) {
 }
 
 func TestModifyPack(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)
@@ -102,8 +97,7 @@ func TestModifyPack(t *testing.T) {
 }
 
 func TestDeletePack(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)
@@ -127,8 +121,7 @@ func TestDeletePack(t *testing.T) {
 }
 
 func TestAddQueryToPack(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)
@@ -163,8 +156,7 @@ func TestAddQueryToPack(t *testing.T) {
 }
 
 func TestGetQueriesInPack(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)
@@ -195,8 +187,7 @@ func TestGetQueriesInPack(t *testing.T) {
 }
 
 func TestRemoveQueryFromPack(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)

--- a/server/service_queries_test.go
+++ b/server/service_queries_test.go
@@ -3,15 +3,13 @@ package server
 import (
 	"testing"
 
-	"github.com/kolide/kolide-ose/datastore"
 	"github.com/kolide/kolide-ose/kolide"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
 
 func TestGetAllQueries(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)
@@ -34,8 +32,7 @@ func TestGetAllQueries(t *testing.T) {
 }
 
 func TestGetQuery(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)
@@ -57,8 +54,7 @@ func TestGetQuery(t *testing.T) {
 }
 
 func TestNewQuery(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)
@@ -80,8 +76,7 @@ func TestNewQuery(t *testing.T) {
 }
 
 func TestModifyQuery(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)
@@ -107,8 +102,7 @@ func TestModifyQuery(t *testing.T) {
 }
 
 func TestDeleteQuery(t *testing.T) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)

--- a/server/service_sessions_test.go
+++ b/server/service_sessions_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kolide/kolide-ose/datastore"
 	"github.com/kolide/kolide-ose/kolide"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,8 +57,7 @@ func TestAuthenticate(t *testing.T) {
 }
 
 func setupLoginTests(t *testing.T) (kolide.Service, kolide.UserPayload, kolide.User) {
-	ds, err := datastore.New("gorm-sqlite3", ":memory:")
-	assert.Nil(t, err)
+	ds := setup(t)
 
 	svc, err := newTestService(ds)
 	assert.Nil(t, err)


### PR DESCRIPTION
Trying to close #146 and realized that the current `kolide prepare db` does not seem 
well thought out. 
I propose dropping `kolide prepare db` in favor of 

```
kolide db migrate // starts a migration
kolide db reset     // drops all tables
```

Looking for more input. Keep in mind that someone installing kolide from source already has to do:

```
make deps
make generate
make build

// prepare db steps here
// probably some cert related command here

kolide serve
```

Every additional command we add right now just increases the setup pains a user has to go through. 
