### PR TITLE
change force_password_reset flag to false after a succesful reset

### DIFF
--- a/server/service_users.go
+++ b/server/service_users.go
@@ -77,6 +77,7 @@ func (svc service) ModifyUser(ctx context.Context, userID uint, p kolide.UserPay
 		}
 		user.Password = hashed
 		user.Salt = salt
+		user.AdminForcedPasswordReset = false
 	}
 
 	err = svc.saveUser(user)


### PR DESCRIPTION
If a user has successfully reset their password, set the `AdminForcedPasswordReset` flag back to false. 
