### PR TITLE
Lower test verbosity in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ lint-go:
 lint: lint-go lint-js
 
 test-go:
-	go test -v -cover $(shell glide nv)
+	go test -cover $(shell glide nv)
 
 test-js:
 	_mocha --compilers js:babel-core/register \


### PR DESCRIPTION
I think that the output here is much more useful when allowing go to
determine when the output of a test should be displayed.
