### PR TITLE
Removing environment specific JavaScript config

### DIFF
--- a/frontend/config/config.DEV.js
+++ b/frontend/config/config.DEV.js
@@ -1,5 +1,0 @@
-import { environments } from './index.js';
-
-export default {
-  env: environments.development,
-};

--- a/frontend/config/config.PROD.js
+++ b/frontend/config/config.PROD.js
@@ -1,5 +1,0 @@
-import { environments } from './index.js';
-
-export default {
-  env: environments.production,
-};

--- a/frontend/config/index.js
+++ b/frontend/config/index.js
@@ -1,9 +1,0 @@
-export const environments = {
-  development: 'DEV',
-  production: 'PROD',
-};
-const env = process.env.NODE_ENV || environments.development;
-const configFileLocation = `./config.${env}.js`;
-const settings = require(configFileLocation).default;
-
-export default { environments, settings };

--- a/frontend/utilities/local.js
+++ b/frontend/utilities/local.js
@@ -1,7 +1,4 @@
-import config from '../config';
-
 const { window } = global;
-const { settings } = config;
 
 const local = {
   clear: () => {
@@ -11,15 +8,13 @@ const local = {
   },
   getItem: (itemName) => {
     const { localStorage } = window;
-    const { env } = settings;
 
-    return localStorage.getItem(`KOLIDE-${env}::${itemName}`);
+    return localStorage.getItem(`KOLIDE::${itemName}`);
   },
   setItem: (itemName, value) => {
     const { localStorage } = window;
-    const { env } = settings;
 
-    return localStorage.setItem(`KOLIDE-${env}::${itemName}`, value);
+    return localStorage.setItem(`KOLIDE::${itemName}`, value);
   },
 };
 


### PR DESCRIPTION
This isn't used for anything other than prefixing local storage and I think `if PROD` control flow statements are generally A Bad Idea, so here's a PR which is red.
