### PR TITLE
bug-fix/reset password page

### DIFF
--- a/frontend/components/AuthenticatedRoutes/AuthenticatedRoutes.tests.jsx
+++ b/frontend/components/AuthenticatedRoutes/AuthenticatedRoutes.tests.jsx
@@ -17,7 +17,7 @@ describe('AuthenticatedRoutes - component', () => {
     type: '@@router/CALL_HISTORY_METHOD',
     payload: {
       method: 'push',
-      args: ['/reset_password'],
+      args: ['/login/reset'],
     },
   };
   const renderedText = 'This text was rendered';

--- a/frontend/components/LoginRoutes/LoginRoutes.jsx
+++ b/frontend/components/LoginRoutes/LoginRoutes.jsx
@@ -29,14 +29,14 @@ export class LoginRoutes extends Component {
 
   render () {
     const { containerStyles, logoStyles } = componentStyles;
-    const { children } = this.props;
+    const { children, location: { pathname } } = this.props;
 
     return (
       <div style={containerStyles}>
         <img style={logoStyles} alt="Kolide text logo" src="/assets/images/kolide-logo-text.svg" />
-        <LoginPage />
+        <LoginPage pathname={pathname} />
         <RouteTransition
-          pathname={this.props.location.pathname}
+          pathname={pathname}
           atEnter={{
             scale: 1.3,
             opacity: 0,
@@ -61,4 +61,10 @@ export class LoginRoutes extends Component {
   }
 }
 
-export default connect()(LoginRoutes);
+const mapStateToProps = (state, ownProps) => {
+  const { location } = ownProps;
+
+  return { location };
+};
+
+export default connect(mapStateToProps)(LoginRoutes);

--- a/frontend/pages/HomePage/HomePage.jsx
+++ b/frontend/pages/HomePage/HomePage.jsx
@@ -17,7 +17,7 @@ export class HomePage extends Component {
 
     return (
       <div style={containerStyles}>
-        <Avatar size="small" style={avatarStyles} user={user} />
+        {user && <Avatar size="small" style={avatarStyles} user={user} />}
         <span>You are successfully logged in! </span>
         {user && <Link to={LOGOUT}>Logout</Link>}
       </div>

--- a/frontend/pages/LoginPage/LoginPage.jsx
+++ b/frontend/pages/LoginPage/LoginPage.jsx
@@ -4,18 +4,17 @@ import { push } from 'react-router-redux';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import { clearAuthErrors, loginUser } from '../../redux/nodes/auth/actions';
 import debounce from '../../utilities/debounce';
-import local from '../../utilities/local';
 import LoginForm from '../../components/forms/LoginForm';
 import LoginSuccessfulPage from '../LoginSuccessfulPage';
 import paths from '../../router/paths';
 import './styles.scss';
 
 export class LoginPage extends Component {
-
   static propTypes = {
     dispatch: PropTypes.func,
     error: PropTypes.string,
     loading: PropTypes.bool,
+    pathname: PropTypes.string,
     user: PropTypes.object,
   };
 
@@ -27,11 +26,10 @@ export class LoginPage extends Component {
   }
 
   componentWillMount () {
-    const { dispatch } = this.props;
+    const { dispatch, pathname, user } = this.props;
+    const { HOME, LOGIN } = paths;
 
-    if (local.getItem('auth_token')) {
-      return dispatch(push('/'));
-    }
+    if (user && pathname === LOGIN) return dispatch(push(HOME));
 
     return false;
   }

--- a/frontend/pages/LoginPage/LoginPage.tests.jsx
+++ b/frontend/pages/LoginPage/LoginPage.tests.jsx
@@ -24,6 +24,7 @@ describe('LoginPage - component', () => {
 
     it('redirects to the home page', () => {
       const mockStore = reduxMockStore({ auth: { user } });
+      const props = { pathname: '/login' };
       const redirectAction = {
         type: '@@router/CALL_HISTORY_METHOD',
         payload: {
@@ -32,7 +33,7 @@ describe('LoginPage - component', () => {
         },
       };
 
-      mount(connectedComponent(LoginPage, { mockStore }));
+      mount(connectedComponent(LoginPage, { props, mockStore }));
       expect(mockStore.getActions()).toInclude(redirectAction);
     });
   });

--- a/frontend/router/paths.js
+++ b/frontend/router/paths.js
@@ -4,5 +4,5 @@ export default {
   HOME: '/',
   LOGIN: '/login',
   LOGOUT: '/logout',
-  RESET_PASSWORD: '/reset_password',
+  RESET_PASSWORD: '/login/reset',
 };


### PR DESCRIPTION
This PR fixes a bug that was causing an infinite loop when a user is forced to reset their password.

The first issue is that we forgot to update the `paths` file when changing how the routes are structured for the password reset page.

The second issue was that the `LoginPage` was not being rendered as an `IndexRoute` in the router, and was instead being rendered for all `LoginRoutes` (including the `PasswordResetPage`). This caused the infinite loop of redirecting between the home page and the password reset page.
