### PR TITLE
Fix incorrect decode function in GetAllQueries

### DIFF
--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -184,7 +184,7 @@ func makeKolideKitHandlers(ctx context.Context, e KolideEndpoints, opts []kithtt
 		ListInvites:                   newServer(e.ListInvites, decodeNoParamsRequest),
 		DeleteInvite:                  newServer(e.DeleteInvite, decodeDeleteInviteRequest),
 		GetQuery:                      newServer(e.GetQuery, decodeGetQueryRequest),
-		GetAllQueries:                 newServer(e.GetAllQueries, decodeGetQueryRequest),
+		GetAllQueries:                 newServer(e.GetAllQueries, decodeNoParamsRequest),
 		CreateQuery:                   newServer(e.CreateQuery, decodeCreateQueryRequest),
 		ModifyQuery:                   newServer(e.ModifyQuery, decodeModifyQueryRequest),
 		DeleteQuery:                   newServer(e.DeleteQuery, decodeDeleteQueryRequest),


### PR DESCRIPTION
This was causing an error to be returned instead of results.
