### PR TITLE
only set AdminForcedPasswordReset if payload value is true

### DIFF
--- a/server/service/service_users.go
+++ b/server/service/service_users.go
@@ -71,9 +71,11 @@ func (svc service) ModifyUser(ctx context.Context, userID uint, p kolide.UserPay
 	}
 
 	if p.AdminForcedPasswordReset != nil {
-		err = svc.RequestPasswordReset(ctx, user.Email)
-		if err != nil {
-			return nil, err
+		if *p.AdminForcedPasswordReset {
+			err = svc.RequestPasswordReset(ctx, user.Email)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #287 which turned out to be a backend issue. 
The server was only checking that the value was not nil, and never checking for `true/false`
