### PR TITLE
Lowercase strings which should be case insensitive

### DIFF
--- a/server/service/transport_invites.go
+++ b/server/service/transport_invites.go
@@ -3,6 +3,7 @@ package service
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"golang.org/x/net/context"
 )
@@ -11,6 +12,9 @@ func decodeCreateInviteRequest(ctx context.Context, r *http.Request) (interface{
 	var req createInviteRequest
 	if err := json.NewDecoder(r.Body).Decode(&req.payload); err != nil {
 		return nil, err
+	}
+	if req.payload.Email != nil {
+		*req.payload.Email = strings.ToLower(*req.payload.Email)
 	}
 
 	return req, nil

--- a/server/service/transport_invites_test.go
+++ b/server/service/transport_invites_test.go
@@ -23,15 +23,33 @@ func TestDecodeCreateInviteRequest(t *testing.T) {
 		assert.Equal(t, uint(1), *params.payload.InvitedBy)
 	}).Methods("POST")
 
-	var body bytes.Buffer
-	body.Write([]byte(`{
+	t.Run("lowercase email", func(t *testing.T) {
+		var body bytes.Buffer
+		body.Write([]byte(`{
         "name": "foo",
         "email": "foo@kolide.co",
         "invited_by": 1
     }`))
 
-	router.ServeHTTP(
-		httptest.NewRecorder(),
-		httptest.NewRequest("POST", "/api/v1/kolide/invites", &body),
-	)
+		router.ServeHTTP(
+			httptest.NewRecorder(),
+			httptest.NewRequest("POST", "/api/v1/kolide/invites", &body),
+		)
+	})
+
+	t.Run("uppercase email", func(t *testing.T) {
+		// email string should be lowerased after decode.
+		var body bytes.Buffer
+		body.Write([]byte(`{
+        "name": "foo",
+        "email": "Foo@Kolide.co",
+        "invited_by": 1
+    }`))
+
+		router.ServeHTTP(
+			httptest.NewRecorder(),
+			httptest.NewRequest("POST", "/api/v1/kolide/invites", &body),
+		)
+	})
+
 }

--- a/server/service/transport_sessions.go
+++ b/server/service/transport_sessions.go
@@ -3,6 +3,7 @@ package service
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"golang.org/x/net/context"
 )
@@ -44,5 +45,6 @@ func decodeLoginRequest(ctx context.Context, r *http.Request) (interface{}, erro
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return nil, err
 	}
+	req.Username = strings.ToLower(req.Username)
 	return req, nil
 }

--- a/server/service/transport_sessions_test.go
+++ b/server/service/transport_sessions_test.go
@@ -85,15 +85,29 @@ func TestDecodeLoginRequest(t *testing.T) {
 		assert.Equal(t, "foo", params.Username)
 		assert.Equal(t, "bar", params.Password)
 	}).Methods("POST")
-
-	var body bytes.Buffer
-	body.Write([]byte(`{
+	t.Run("lowercase username", func(t *testing.T) {
+		var body bytes.Buffer
+		body.Write([]byte(`{
         "username": "foo",
         "password": "bar"
     }`))
 
-	router.ServeHTTP(
-		httptest.NewRecorder(),
-		httptest.NewRequest("POST", "/api/v1/kolide/login", &body),
-	)
+		router.ServeHTTP(
+			httptest.NewRecorder(),
+			httptest.NewRequest("POST", "/api/v1/kolide/login", &body),
+		)
+	})
+	t.Run("uppercase username", func(t *testing.T) {
+		var body bytes.Buffer
+		body.Write([]byte(`{
+        "username": "Foo",
+        "password": "bar"
+    }`))
+
+		router.ServeHTTP(
+			httptest.NewRecorder(),
+			httptest.NewRequest("POST", "/api/v1/kolide/login", &body),
+		)
+	})
+
 }


### PR DESCRIPTION
Lowercase strings like `Email` and `Username` where appropriate.

Fixes #299
Closes #300
