### PR TITLE
formData mimics query attribute names

### DIFF
--- a/frontend/components/forms/queries/QueryForm/QueryForm.jsx
+++ b/frontend/components/forms/queries/QueryForm/QueryForm.jsx
@@ -35,7 +35,7 @@ class QueryForm extends Component {
       formData: {
         description,
         name,
-        queryText,
+        query: queryText,
       },
     };
   }
@@ -48,7 +48,7 @@ class QueryForm extends Component {
       formData: {
         description,
         name,
-        queryText,
+        query: queryText,
       },
     });
   }

--- a/frontend/components/forms/queries/QueryForm/QueryForm.tests.jsx
+++ b/frontend/components/forms/queries/QueryForm/QueryForm.tests.jsx
@@ -37,7 +37,7 @@ describe('QueryForm - component', () => {
       formData: {
         description: 'new description',
         name: 'new name',
-        queryText,
+        query: queryText,
       },
     });
   });
@@ -78,7 +78,7 @@ describe('QueryForm - component', () => {
     expect(onSaveChangesSpy).toHaveBeenCalledWith({
       description: query.description,
       name: 'New query name',
-      queryText,
+      query: queryText,
     });
   });
 
@@ -130,7 +130,7 @@ describe('QueryForm - component', () => {
     expect(onSaveAsNewSpy).toHaveBeenCalledWith({
       description: query.description,
       name: 'New query name',
-      queryText,
+      query: queryText,
     });
   });
 

--- a/frontend/components/forms/queries/QueryForm/helpers.js
+++ b/frontend/components/forms/queries/QueryForm/helpers.js
@@ -3,7 +3,7 @@ import { isEmpty } from 'lodash';
 const formChanged = (formData, query) => {
   return formData.name !== query.name ||
     formData.description !== query.description ||
-    formData.queryText !== query.query;
+    formData.query !== query.query;
 };
 
 const canSaveAsNew = (formData, query) => {

--- a/frontend/components/queries/QueryComposer/QueryComposer.tests.jsx
+++ b/frontend/components/queries/QueryComposer/QueryComposer.tests.jsx
@@ -69,7 +69,7 @@ describe('QueryComposer - component', () => {
     expect(onSaveQueryFormSubmitSpy).toHaveBeenCalledWith({
       description: 'My query description',
       name: 'My query name',
-      queryText,
+      query: queryText,
     });
   });
 
@@ -111,7 +111,7 @@ describe('QueryComposer - component', () => {
     expect(onSaveChangesSpy).toHaveBeenCalledWith({
       description: query.description,
       name: 'My new query name',
-      queryText: query.query,
+      query: query.query,
     });
   });
 


### PR DESCRIPTION
This fixes a bug that allowed users to submit the form to update a
query when no changes were made