### PR TITLE
get users if the only user in state is the current user

### DIFF
--- a/frontend/pages/Admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/Admin/UserManagementPage/UserManagementPage.jsx
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { first, isEqual, size } from 'lodash';
 
 import entityGetter from '../../../redux/utilities/entityGetter';
 import Button from '../../../components/buttons/Button';
@@ -29,9 +30,10 @@ class UserManagementPage extends Component {
   }
 
   componentWillMount () {
-    const { dispatch, invites, users } = this.props;
+    const { currentUser, dispatch, invites, users } = this.props;
 
-    if (!users.length) {
+    if (!size(users) ||
+      (size(users) === 1 && isEqual(first(users), currentUser))) {
       dispatch(userActions.loadAll());
     }
 

--- a/frontend/pages/Admin/UserManagementPage/UserManagementPage.tests.jsx
+++ b/frontend/pages/Admin/UserManagementPage/UserManagementPage.tests.jsx
@@ -12,6 +12,7 @@ const currentUser = {
   position: 'Head of Gnar',
   username: 'gnardog',
 };
+const loadUsersAction = { type: 'users_LOAD_REQUEST' };
 const store = {
   auth: {
     user: {
@@ -53,5 +54,50 @@ describe('UserManagementPage - component', () => {
     const page = mount(connectedComponent(UserManagementPage, { mockStore }));
 
     expect(page.text()).toInclude('Listing 2 users');
+  });
+
+  it('gets all users if there are no users in state', () => {
+    const mockStore = reduxMockStore({
+      ...store,
+      entities: {
+        ...store.entities,
+        users: {
+          ...store.entities.users,
+          data: {},
+        },
+      },
+    });
+
+    mount(connectedComponent(UserManagementPage, { mockStore }));
+
+    expect(mockStore.getActions()).toInclude(loadUsersAction);
+  });
+
+  it('gets all users if the only user in state is the current user', () => {
+    const mockStore = reduxMockStore(store);
+
+    mount(connectedComponent(UserManagementPage, { mockStore }));
+
+    expect(mockStore.getActions()).toInclude(loadUsersAction);
+  });
+
+  it('does not get users if users are already loaded', () => {
+    const mockStore = reduxMockStore({
+      ...store,
+      entities: {
+        ...store.entities,
+        users: {
+          ...store.entities.users,
+          data: {
+            1: { ...currentUser },
+            2: { id: 2, email: 'hi@gnar.dog', full_name: 'GnarDog' },
+          },
+        },
+      },
+    });
+
+    mount(connectedComponent(UserManagementPage, { mockStore }));
+
+    expect(mockStore.getActions()).toNotInclude(loadUsersAction);
   });
 });


### PR DESCRIPTION
@kyleknighted found the following bug:

1) Log in as the admin user
2) Visit the admin user management page (you will see the 'admin' and 'user' users)
3) Require password reset on the admin user
4) Refresh the page
5) Reset password and log in
6) Visit the admin user management page
7) BUG: only the admin user is shown

This bug was happening because of the patch request on the admin after changing their password. This call adds the admin to the users state and we were not making the call to get users if there were users already in state. This PR makes the call to get users if the only user in state is the current user.