### PR TITLE
Removing binary ignores from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# binaries
-kolide-ose
-*.exe
-
 # output directories
 build
 vendor


### PR DESCRIPTION
We don't need these anymore, since `make` puts output binaries into `build/`, which is already in this file.