### PR TITLE
Return count of hosts in targets search for each label

### DIFF
--- a/server/service/endpoint_targets.go
+++ b/server/service/endpoint_targets.go
@@ -26,6 +26,7 @@ type hostSearchResult struct {
 type labelSearchResult struct {
 	kolide.Label
 	DisplayText string `json:"display_text"`
+	Count       uint   `json:"count"`
 }
 
 type targetsData struct {
@@ -70,10 +71,15 @@ func makeSearchTargetsEndpoint(svc kolide.Service) endpoint.Endpoint {
 		}
 
 		for _, label := range results.Labels {
+			count, err := svc.CountHostsInTargets(ctx, nil, []uint{label.ID})
+			if err != nil {
+				return searchTargetsResponse{Err: err}, nil
+			}
 			targets.Labels = append(targets.Labels,
 				labelSearchResult{
 					label,
 					label.Name,
+					count,
 				},
 			)
 		}


### PR DESCRIPTION
Now, a request to `/api/v1/kolide/targets` with a body of `{"query": "mysql"}`

will return a count field in each label which is the number of hosts in that label.

```
{
  "targets": {
    "hosts": [],
    "labels": [
      {
        "id": 3,
        "name": "mysql",
        "description": "Hosts running the MySQL daemon",
        "query": "select * from processes where name like '%mysqld%';",
        "platform": "",
        "display_text": "mysql",
        "count": 0
      }
    ]
  }
}
```

close #468