### PR TITLE
Fixing make generate-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ generate-dev: .prefix
 	go-bindata -debug -pkg=service \
 		-o=server/service/bindata.go \
 		frontend/templates/ assets/...
+	go-bindata -o=server/datastore/mysql/bindata.go -pkg=mysql db/
 	webpack --progress --colors --watch --notify
 
 deps:


### PR DESCRIPTION
This commit adds the SQL bindata file generation to generate-dev