### PR TITLE
Configures redux devtools

### DIFF
--- a/frontend/redux/store.js
+++ b/frontend/redux/store.js
@@ -14,10 +14,14 @@ const appliedMiddleware = applyMiddleware(
   authMiddleware,
 );
 
+const composeEnhancers = process.env.NODE_ENV !== 'production' &&
+  typeof global.window === 'object' &&
+  global.window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ?
+  global.window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ : compose;
 const store = createStore(
   reducers,
   initialState,
-  compose(appliedMiddleware),
+  composeEnhancers(appliedMiddleware),
 );
 
 export default store;


### PR DESCRIPTION
This configures redux devtools so we can check out state in the browser during development. It disables dev tools in production (when NODE_ENV is set to 'production')

http://zalmoxisus.github.io/redux-devtools-extension/