### PR TITLE
Updated so you can choose to run 1.8.2 or 2.1.2 osquery

### DIFF
--- a/tools/osquery/README.md
+++ b/tools/osquery/README.md
@@ -21,7 +21,9 @@ Using Docker enables us to rapidly spin up and down pre-configured `osqueryd` in
 
 Docker and docker-compose are the only dependencies. The necessary container images will be pulled from Docker Cloud on first run.
 
-Before using the following commands, set the environment variable `LOCALHOST` to the public IP (127.0.0.1 will not work) of the docker host machine. This will allow the containers to connect to the local Kolide server.
+Before using the following commands, set the environment variable `LOCALHOST` to the public IP (127.0.0.1 will not work) of the docker host machine. This will allow the containers to connect to the local Kolide server. You will also need to
+set `KOLIDE_OSQUERY_VERSION` to either `1.8.2` or `latest` (currently 2.1.2) to indicate which version of osquery that you want to run on your
+containers.
 
 ### Running osqueryd
 

--- a/tools/osquery/docker-compose.yml
+++ b/tools/osquery/docker-compose.yml
@@ -1,8 +1,9 @@
+
 version: '2'
 
 services:
   ubuntu14-osquery:
-    image: kolide/osquery
+    image: "kolide/osquery:${KOLIDE_OSQUERY_VERSION}"
     volumes:
       - ./kolide.crt:/etc/osquery/kolide.crt
       - ./example_osquery.flags:/etc/osquery/osquery.flags
@@ -14,7 +15,7 @@ services:
     command: osqueryd --flagfile=/etc/osquery/osquery.flags
 
   centos7-osquery:
-    image: kolide/centos7-osquery
+    image: "kolide/centos7-osquery:${KOLIDE_OSQUERY_VERSION}"
     volumes:
       - ./kolide.crt:/etc/osquery/kolide.crt
       - ./example_osquery.flags:/etc/osquery/osquery.flags


### PR DESCRIPTION
Note that I've created tagged versions of both kolide/osquery and kolide/centos7-osquery in Docker Hub to facilitate this change.  Right now the latest tag image runs 2.1.2. 