### PR TITLE
print connection sleep interval duration in seconds

### DIFF
--- a/server/datastore/mysql/datastore.go
+++ b/server/datastore/mysql/datastore.go
@@ -50,10 +50,10 @@ func New(dbConnectString string, c clock.Clock, opts ...DBOption) (*Datastore, e
 			// we're connected!
 			break
 		}
-		sleep := time.Duration(attempt)
+		interval := time.Duration(attempt) * time.Second
 		options.logger.Log("mysql", fmt.Sprintf(
-			"could not connect to db: %v, sleeping %v", dbError, sleep))
-		time.Sleep(sleep * time.Second)
+			"could not connect to db: %v, sleeping %v", dbError, interval))
+		time.Sleep(interval)
 	}
 
 	if dbError != nil {


### PR DESCRIPTION
The duration was printed with a "ns" interval, even
though the sleep time was in seconds.

Just a small inconsistency. 