### PR TITLE
switch circle.yml to go1.8 builder image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,9 +10,10 @@ dependencies:
     - docker info
     - docker login -e $DOCKER_HUB_EMAIL -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
   override:
-    - docker pull kolide/kolide-builder:1.7
     - docker pull redis
-    - docker run -v $(pwd):/go/src/github.com/kolide/kolide-ose -v /home/ubuntu/.go_workspace/pkg:/go/pkg kolide/kolide-builder:1.7 --deps
+    - docker pull mysql:5.7
+    - docker pull kolide/kolide-builder:1.8
+    - docker run -v $(pwd):/go/src/github.com/kolide/kolide-ose -v /home/ubuntu/.go_workspace/pkg:/go/pkg kolide/kolide-builder:1.8 --deps
   cache_directories:
     - "vendor"
     - "node_modules"
@@ -21,7 +22,7 @@ test:
   override:
       - docker run -d --name redis redis
       - docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=toor -e MYSQL_DATABASE=kolide -e MYSQL_USER=kolide -e MYSQL_PASSWORD=kolide mysql:5.7
-      - docker run --link redis:redis --link mysql:mysql -e MYSQL_TEST=true -e REDIS_TEST=true -v $(pwd):/go/src/github.com/kolide/kolide-ose -v /home/ubuntu/.go_workspace/pkg:/go/pkg kolide/kolide-builder:1.7 --build
+      - docker run --link redis:redis --link mysql:mysql -e MYSQL_TEST=true -e REDIS_TEST=true -v $(pwd):/go/src/github.com/kolide/kolide-ose -v /home/ubuntu/.go_workspace/pkg:/go/pkg kolide/kolide-builder:1.8 --build
       - docker stop $(docker ps -a -q)
 
 deployment:


### PR DESCRIPTION
This is a WIP until the official docker container is added. 
I'm a bit reluctant to add it at all, because Circle-CI doesn't seem to officially support parallel builds, so you have to either pick what you think 'latest' is, or double the build time on CI.