### PR TITLE
use random string instead of JWT for tokens.

### DIFF
--- a/server/service/service_invites.go
+++ b/server/service/service_invites.go
@@ -1,9 +1,9 @@
 package service
 
 import (
+	"encoding/base64"
 	"errors"
 
-	jwt "github.com/dgrijalva/jwt-go"
 	kolide_errors "github.com/kolide/kolide-ose/server/errors"
 	"github.com/kolide/kolide-ose/server/kolide"
 	"golang.org/x/net/context"
@@ -25,10 +25,11 @@ func (svc service) InviteNewUser(ctx context.Context, payload kolide.InvitePaylo
 		return nil, err
 	}
 
-	token, err := jwt.New(jwt.SigningMethodHS256).SignedString([]byte(svc.config.App.TokenKey))
+	random, err := kolide.RandomText(svc.config.App.TokenKeySize)
 	if err != nil {
 		return nil, err
 	}
+	token := base64.URLEncoding.EncodeToString([]byte(random))
 
 	invite := &kolide.Invite{
 		Email:     *payload.Email,

--- a/server/service/service_users.go
+++ b/server/service/service_users.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/kolide/kolide-ose/server/contexts/viewer"
 	"github.com/kolide/kolide-ose/server/kolide"
 	"golang.org/x/net/context"
@@ -180,10 +179,11 @@ func (svc service) RequestPasswordReset(ctx context.Context, email string) error
 		}
 	}
 
-	token, err := jwt.New(jwt.SigningMethodHS256).SignedString([]byte(svc.config.App.TokenKey))
+	random, err := kolide.RandomText(svc.config.App.TokenKeySize)
 	if err != nil {
 		return err
 	}
+	token := base64.URLEncoding.EncodeToString([]byte(random))
 
 	request := &kolide.PasswordResetRequest{
 		UpdateCreateTimestamps: kolide.UpdateCreateTimestamps{


### PR DESCRIPTION
uses a random URL encoded base64 string as the token for password reset
and invites.

@mikestone14 can you verify that these tokens work for you in #583 ?