### PR TITLE
set created_at time for invites in inmem

### DIFF
--- a/server/datastore/inmem/invites.go
+++ b/server/datastore/inmem/invites.go
@@ -2,6 +2,7 @@ package inmem
 
 import (
 	"sort"
+	"time"
 
 	"github.com/kolide/kolide-ose/server/errors"
 	"github.com/kolide/kolide-ose/server/kolide"
@@ -16,6 +17,11 @@ func (orm *Datastore) NewInvite(invite *kolide.Invite) (*kolide.Invite, error) {
 		if in.Email == invite.Email {
 			return nil, errors.ErrExists
 		}
+	}
+
+	// set time if missing.
+	if invite.CreatedAt.IsZero() {
+		invite.CreatedAt = time.Now()
 	}
 
 	invite.ID = uint(len(orm.invites) + 1)


### PR DESCRIPTION
This PR addresses invite tokens always showing up as expired. 

A more general fix should be applied when #585 is resolved. 