### PR TITLE
Fix parentheses in labels search SQL

### DIFF
--- a/server/datastore/datastore_labels_test.go
+++ b/server/datastore/datastore_labels_test.go
@@ -212,18 +212,18 @@ func testSearchLabels(t *testing.T, db kolide.Datastore) {
 	assert.Contains(t, labels, *all)
 
 	labels, err = db.SearchLabels("foo")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Len(t, labels, 3)
 	assert.Contains(t, labels, *all)
 
-	label, err := db.SearchLabels("foo", l3.ID, all.ID)
-	assert.Nil(t, err)
-	assert.Len(t, label, 1)
-	assert.Equal(t, "foo", label[0].Name)
+	labels, err = db.SearchLabels("foo", all.ID, l3.ID)
+	require.Nil(t, err)
+	assert.Len(t, labels, 1)
+	assert.Equal(t, "foo", labels[0].Name)
 
-	none, err := db.SearchLabels("xxx")
-	assert.Nil(t, err)
-	assert.Len(t, none, 1)
+	labels, err = db.SearchLabels("xxx")
+	require.Nil(t, err)
+	assert.Len(t, labels, 1)
 	assert.Contains(t, labels, *all)
 }
 

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -220,12 +220,14 @@ func (d *Datastore) searchLabelsWithOmits(query string, omit ...uint) ([]kolide.
 		SELECT *
 		FROM labels
 		WHERE (
-			MATCH(name) AGAINST(? IN BOOLEAN MODE)
-			AND NOT deleted
-		)
-		OR (
-			label_type=?
-			AND name = 'All Hosts'
+			(
+				MATCH(name) AGAINST(? IN BOOLEAN MODE)
+				AND NOT deleted
+			)
+			OR (
+				label_type=?
+				AND name = 'All Hosts'
+			)
 		)
 		AND id NOT IN (?)
 		ORDER BY id ASC
@@ -250,7 +252,6 @@ func (d *Datastore) searchLabelsWithOmits(query string, omit ...uint) ([]kolide.
 
 // SearchLabels performs wildcard searches on kolide.Label name
 func (d *Datastore) SearchLabels(query string, omit ...uint) ([]kolide.Label, error) {
-
 	if len(omit) > 0 {
 		return d.searchLabelsWithOmits(query, omit...)
 	}
@@ -263,12 +264,14 @@ func (d *Datastore) SearchLabels(query string, omit ...uint) ([]kolide.Label, er
 		SELECT *
 		FROM labels
 		WHERE (
-			MATCH(name) AGAINST(? IN BOOLEAN MODE)
-			AND NOT deleted
-		)
-		OR (
-			label_type=?
-			AND name = 'All Hosts'
+			(
+				MATCH(name) AGAINST(? IN BOOLEAN MODE)
+				AND NOT deleted
+			)
+			OR (
+				label_type=?
+				AND name = 'All Hosts'
+			)
 		)
 		ORDER BY id ASC
 		LIMIT 10


### PR DESCRIPTION
Operator precedence was causing incorrect results to be returned. The failing
test was missed because the CI results did not appear in Github before merging.