### PR TITLE
Use redis for distributed query results when not in dev mode

### DIFF
--- a/cli/serve.go
+++ b/cli/serve.go
@@ -93,7 +93,15 @@ the way that the kolide server works.
 				}
 			}
 
-			svc, err := service.NewService(ds, pubsub.NewInmemQueryResults(), logger, config, mailService, clock.C)
+			var resultStore kolide.QueryResultStore
+			if devMode {
+				resultStore = pubsub.NewInmemQueryResults()
+			} else {
+				redisPool := pubsub.NewRedisPool(config.Redis.Address, config.Redis.Password)
+				resultStore = pubsub.NewRedisQueryResults(redisPool)
+			}
+
+			svc, err := service.NewService(ds, resultStore, logger, config, mailService, clock.C)
 			if err != nil {
 				initFatal(err, "initializing service")
 			}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -22,6 +22,12 @@ type MysqlConfig struct {
 	Database string
 }
 
+// RedisConfig defines configs related to Redis
+type RedisConfig struct {
+	Address  string
+	Password string
+}
+
 // ServerConfig defines configs related to the Kolide server
 type ServerConfig struct {
 	Address string
@@ -79,6 +85,7 @@ type LoggingConfig struct {
 // updated to set and retrieve the configurations as appropriate.
 type KolideConfig struct {
 	Mysql   MysqlConfig
+	Redis   RedisConfig
 	Server  ServerConfig
 	Auth    AuthConfig
 	App     AppConfig
@@ -96,6 +103,10 @@ func (man Manager) addConfigs() {
 	man.addConfigString("mysql.username", "kolide")
 	man.addConfigString("mysql.password", "kolide")
 	man.addConfigString("mysql.database", "kolide")
+
+	// Redis
+	man.addConfigString("redis.address", "localhost:6379")
+	man.addConfigString("redis.password", "")
 
 	// Server
 	man.addConfigString("server.address", "0.0.0.0:8080")
@@ -147,6 +158,10 @@ func (man Manager) LoadConfig() KolideConfig {
 			Username: man.getConfigString("mysql.username"),
 			Password: man.getConfigString("mysql.password"),
 			Database: man.getConfigString("mysql.database"),
+		},
+		Redis: RedisConfig{
+			Address:  man.getConfigString("redis.address"),
+			Password: man.getConfigString("redis.password"),
 		},
 		Server: ServerConfig{
 			Address: man.getConfigString("server.address"),


### PR DESCRIPTION
- Add appropriate configs for Redis
- Use the Redis pubsub store by default, inmem in dev mode