### PR TITLE
Rename inmem method receivers for consistency

### DIFF
--- a/server/datastore/inmem/app.go
+++ b/server/datastore/inmem/app.go
@@ -5,30 +5,30 @@ import (
 	"github.com/kolide/kolide-ose/server/kolide"
 )
 
-func (orm *Datastore) NewAppConfig(info *kolide.AppConfig) (*kolide.AppConfig, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) NewAppConfig(info *kolide.AppConfig) (*kolide.AppConfig, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
 	info.ID = 1
-	orm.orginfo = info
+	d.orginfo = info
 	return info, nil
 }
 
-func (orm *Datastore) AppConfig() (*kolide.AppConfig, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) AppConfig() (*kolide.AppConfig, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	if orm.orginfo != nil {
-		return orm.orginfo, nil
+	if d.orginfo != nil {
+		return d.orginfo, nil
 	}
 
 	return nil, errors.ErrNotFound
 }
 
-func (orm *Datastore) SaveAppConfig(info *kolide.AppConfig) error {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) SaveAppConfig(info *kolide.AppConfig) error {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	orm.orginfo = info
+	d.orginfo = info
 	return nil
 }

--- a/server/datastore/inmem/invites.go
+++ b/server/datastore/inmem/invites.go
@@ -9,11 +9,11 @@ import (
 )
 
 // NewInvite creates and stores a new invitation in a DB.
-func (orm *Datastore) NewInvite(invite *kolide.Invite) (*kolide.Invite, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) NewInvite(invite *kolide.Invite) (*kolide.Invite, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	for _, in := range orm.invites {
+	for _, in := range d.invites {
 		if in.Email == invite.Email {
 			return nil, errors.ErrExists
 		}
@@ -24,26 +24,26 @@ func (orm *Datastore) NewInvite(invite *kolide.Invite) (*kolide.Invite, error) {
 		invite.CreatedAt = time.Now()
 	}
 
-	invite.ID = uint(len(orm.invites) + 1)
-	orm.invites[invite.ID] = invite
+	invite.ID = uint(len(d.invites) + 1)
+	d.invites[invite.ID] = invite
 	return invite, nil
 }
 
 // Invites lists all invites in the datastore.
-func (orm *Datastore) ListInvites(opt kolide.ListOptions) ([]*kolide.Invite, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) ListInvites(opt kolide.ListOptions) ([]*kolide.Invite, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
 	// We need to sort by keys to provide reliable ordering
 	keys := []int{}
-	for k, _ := range orm.invites {
+	for k, _ := range d.invites {
 		keys = append(keys, int(k))
 	}
 	sort.Ints(keys)
 
 	invites := []*kolide.Invite{}
 	for _, k := range keys {
-		invites = append(invites, orm.invites[uint(k)])
+		invites = append(invites, d.invites[uint(k)])
 	}
 
 	// Apply ordering
@@ -64,27 +64,27 @@ func (orm *Datastore) ListInvites(opt kolide.ListOptions) ([]*kolide.Invite, err
 	}
 
 	// Apply limit/offset
-	low, high := orm.getLimitOffsetSliceBounds(opt, len(invites))
+	low, high := d.getLimitOffsetSliceBounds(opt, len(invites))
 	invites = invites[low:high]
 
 	return invites, nil
 }
 
-func (orm *Datastore) Invite(id uint) (*kolide.Invite, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
-	if invite, ok := orm.invites[id]; ok {
+func (d *Datastore) Invite(id uint) (*kolide.Invite, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+	if invite, ok := d.invites[id]; ok {
 		return invite, nil
 	}
 	return nil, errors.ErrNotFound
 }
 
 // InviteByEmail retrieves an invite for a specific email address.
-func (orm *Datastore) InviteByEmail(email string) (*kolide.Invite, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) InviteByEmail(email string) (*kolide.Invite, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	for _, invite := range orm.invites {
+	for _, invite := range d.invites {
 		if invite.Email == email {
 			return invite, nil
 		}
@@ -93,26 +93,26 @@ func (orm *Datastore) InviteByEmail(email string) (*kolide.Invite, error) {
 }
 
 // SaveInvite saves an invitation in the datastore.
-func (orm *Datastore) SaveInvite(invite *kolide.Invite) error {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) SaveInvite(invite *kolide.Invite) error {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	if _, ok := orm.invites[invite.ID]; !ok {
+	if _, ok := d.invites[invite.ID]; !ok {
 		return errors.ErrNotFound
 	}
 
-	orm.invites[invite.ID] = invite
+	d.invites[invite.ID] = invite
 	return nil
 }
 
 // DeleteInvite deletes an invitation.
-func (orm *Datastore) DeleteInvite(invite *kolide.Invite) error {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) DeleteInvite(invite *kolide.Invite) error {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	if _, ok := orm.invites[invite.ID]; !ok {
+	if _, ok := d.invites[invite.ID]; !ok {
 		return errors.ErrNotFound
 	}
-	delete(orm.invites, invite.ID)
+	delete(d.invites, invite.ID)
 	return nil
 }

--- a/server/datastore/inmem/labels.go
+++ b/server/datastore/inmem/labels.go
@@ -12,71 +12,71 @@ import (
 	"github.com/patrickmn/sortutil"
 )
 
-func (orm *Datastore) NewLabel(label *kolide.Label) (*kolide.Label, error) {
+func (d *Datastore) NewLabel(label *kolide.Label) (*kolide.Label, error) {
 	newLabel := *label
 
-	orm.mtx.Lock()
-	for _, l := range orm.labels {
+	d.mtx.Lock()
+	for _, l := range d.labels {
 		if l.Name == label.Name {
 			return nil, kolide_errors.ErrExists
 		}
 	}
 
-	newLabel.ID = orm.nextID(label)
-	orm.labels[newLabel.ID] = &newLabel
-	orm.mtx.Unlock()
+	newLabel.ID = d.nextID(label)
+	d.labels[newLabel.ID] = &newLabel
+	d.mtx.Unlock()
 
 	return &newLabel, nil
 }
 
-func (orm *Datastore) ListLabelsForHost(hid uint) ([]kolide.Label, error) {
+func (d *Datastore) ListLabelsForHost(hid uint) ([]kolide.Label, error) {
 	// First get IDs of label executions for the host
 	resLabels := []kolide.Label{}
 
-	orm.mtx.Lock()
-	for _, lqe := range orm.labelQueryExecutions {
+	d.mtx.Lock()
+	for _, lqe := range d.labelQueryExecutions {
 		if lqe.HostID == hid && lqe.Matches {
-			if label := orm.labels[lqe.LabelID]; label != nil {
+			if label := d.labels[lqe.LabelID]; label != nil {
 				resLabels = append(resLabels, *label)
 			}
 		}
 	}
-	orm.mtx.Unlock()
+	d.mtx.Unlock()
 
 	return resLabels, nil
 }
 
-func (orm *Datastore) LabelQueriesForHost(host *kolide.Host, cutoff time.Time) (map[string]string, error) {
+func (d *Datastore) LabelQueriesForHost(host *kolide.Host, cutoff time.Time) (map[string]string, error) {
 	// Get post-cutoff executions for host
 	execedIDs := map[uint]bool{}
 
-	orm.mtx.Lock()
-	for _, lqe := range orm.labelQueryExecutions {
+	d.mtx.Lock()
+	for _, lqe := range d.labelQueryExecutions {
 		if lqe.HostID == host.ID && (lqe.UpdatedAt == cutoff || lqe.UpdatedAt.After(cutoff)) {
 			execedIDs[lqe.LabelID] = true
 		}
 	}
 
 	queries := map[string]string{}
-	for _, label := range orm.labels {
+	for _, label := range d.labels {
 		if (label.Platform == "" || strings.Contains(label.Platform, host.Platform)) && !execedIDs[label.ID] {
 			queries[strconv.Itoa(int(label.ID))] = label.Query
 		}
 	}
-	orm.mtx.Unlock()
+	d.mtx.Unlock()
 
 	return queries, nil
 }
 
-func (orm *Datastore) getLabelByIDString(id string) (*kolide.Label, error) {
+func (d *Datastore) getLabelByIDString(id string) (*kolide.Label, error) {
 	labelID, err := strconv.Atoi(id)
 	if err != nil {
 		return nil, errors.New("non-int label ID")
 	}
 
-	orm.mtx.Lock()
-	label, ok := orm.labels[uint(labelID)]
-	orm.mtx.Unlock()
+	d.mtx.Lock()
+	label, ok := d.labels[uint(labelID)]
+	d.mtx.Unlock()
 
 	if !ok {
 		return nil, errors.New("label ID not found: " + string(labelID))
@@ -85,17 +85,17 @@ func (orm *Datastore) getLabelByIDString(id string) (*kolide.Label, error) {
 	return label, nil
 }
 
-func (orm *Datastore) RecordLabelQueryExecutions(host *kolide.Host, results map[string]bool, t time.Time) error {
+func (d *Datastore) RecordLabelQueryExecutions(host *kolide.Host, results map[string]bool, t time.Time) error {
 	// Record executions
 	for strLabelID, matches := range results {
-		label, err := orm.getLabelByIDString(strLabelID)
+		label, err := d.getLabelByIDString(strLabelID)
 		if err != nil {
 			return err
 		}
 
 		updated := false
-		orm.mtx.Lock()
-		for _, lqe := range orm.labelQueryExecutions {
+		d.mtx.Lock()
+		for _, lqe := range d.labelQueryExecutions {
 			if lqe.LabelID == label.ID && lqe.HostID == host.ID {
 				// Update existing execution values
 				lqe.UpdatedAt = t
@@ -113,27 +113,27 @@ func (orm *Datastore) RecordLabelQueryExecutions(host *kolide.Host, results map[
 				UpdatedAt: t,
 				Matches:   matches,
 			}
-			lqe.ID = orm.nextID(lqe)
-			orm.labelQueryExecutions[lqe.ID] = &lqe
+			lqe.ID = d.nextID(lqe)
+			d.labelQueryExecutions[lqe.ID] = &lqe
 		}
-		orm.mtx.Unlock()
+		d.mtx.Unlock()
 	}
 
 	return nil
 }
 
-func (orm *Datastore) DeleteLabel(lid uint) error {
-	orm.mtx.Lock()
-	delete(orm.labels, lid)
-	orm.mtx.Unlock()
+func (d *Datastore) DeleteLabel(lid uint) error {
+	d.mtx.Lock()
+	delete(d.labels, lid)
+	d.mtx.Unlock()
 
 	return nil
 }
 
-func (orm *Datastore) Label(lid uint) (*kolide.Label, error) {
-	orm.mtx.Lock()
-	label, ok := orm.labels[lid]
-	orm.mtx.Unlock()
+func (d *Datastore) Label(lid uint) (*kolide.Label, error) {
+	d.mtx.Lock()
+	label, ok := d.labels[lid]
+	d.mtx.Unlock()
 
 	if !ok {
 		return nil, errors.New("Label not found")
@@ -141,21 +141,21 @@ func (orm *Datastore) Label(lid uint) (*kolide.Label, error) {
 	return label, nil
 }
 
-func (orm *Datastore) ListLabels(opt kolide.ListOptions) ([]*kolide.Label, error) {
+func (d *Datastore) ListLabels(opt kolide.ListOptions) ([]*kolide.Label, error) {
 	// We need to sort by keys to provide reliable ordering
 	keys := []int{}
 
-	orm.mtx.Lock()
-	for k, _ := range orm.labels {
+	d.mtx.Lock()
+	for k, _ := range d.labels {
 		keys = append(keys, int(k))
 	}
 	sort.Ints(keys)
 
 	labels := []*kolide.Label{}
 	for _, k := range keys {
-		labels = append(labels, orm.labels[uint(k)])
+		labels = append(labels, d.labels[uint(k)])
 	}
-	orm.mtx.Unlock()
+	d.mtx.Unlock()
 
 	// Apply ordering
 	if opt.OrderKey != "" {
@@ -171,13 +171,13 @@ func (orm *Datastore) ListLabels(opt kolide.ListOptions) ([]*kolide.Label, error
 	}
 
 	// Apply limit/offset
-	low, high := orm.getLimitOffsetSliceBounds(opt, len(labels))
+	low, high := d.getLimitOffsetSliceBounds(opt, len(labels))
 	labels = labels[low:high]
 
 	return labels, nil
 }
 
-func (orm *Datastore) SearchLabels(query string, omit ...uint) ([]kolide.Label, error) {
+func (d *Datastore) SearchLabels(query string, omit ...uint) ([]kolide.Label, error) {
 	omitLookup := map[uint]bool{}
 	for _, o := range omit {
 		omitLookup[o] = true
@@ -185,10 +185,10 @@ func (orm *Datastore) SearchLabels(query string, omit ...uint) ([]kolide.Label, 
 
 	var results []kolide.Label
 
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	for _, l := range orm.labels {
+	for _, l := range d.labels {
 		if len(results) == 10 {
 			break
 		}
@@ -204,22 +204,22 @@ func (orm *Datastore) SearchLabels(query string, omit ...uint) ([]kolide.Label, 
 	return results, nil
 }
 
-func (orm *Datastore) ListHostsInLabel(lid uint) ([]kolide.Host, error) {
+func (d *Datastore) ListHostsInLabel(lid uint) ([]kolide.Host, error) {
 	var hosts []kolide.Host
 
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	for _, lqe := range orm.labelQueryExecutions {
+	for _, lqe := range d.labelQueryExecutions {
 		if lqe.LabelID == lid && lqe.Matches {
-			hosts = append(hosts, *orm.hosts[lqe.HostID])
+			hosts = append(hosts, *d.hosts[lqe.HostID])
 		}
 	}
 
 	return hosts, nil
 }
 
-func (orm *Datastore) ListUniqueHostsInLabels(labels []uint) ([]kolide.Host, error) {
+func (d *Datastore) ListUniqueHostsInLabels(labels []uint) ([]kolide.Host, error) {
 	var hosts []kolide.Host
 
 	labelSet := map[uint]bool{}
@@ -229,13 +229,13 @@ func (orm *Datastore) ListUniqueHostsInLabels(labels []uint) ([]kolide.Host, err
 		labelSet[label] = true
 	}
 
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	for _, lqe := range orm.labelQueryExecutions {
+	for _, lqe := range d.labelQueryExecutions {
 		if labelSet[lqe.LabelID] && lqe.Matches {
 			if !hostSet[lqe.HostID] {
-				hosts = append(hosts, *orm.hosts[lqe.HostID])
+				hosts = append(hosts, *d.hosts[lqe.HostID])
 				hostSet[lqe.HostID] = true
 			}
 		}

--- a/server/datastore/inmem/password_reset.go
+++ b/server/datastore/inmem/password_reset.go
@@ -5,68 +5,68 @@ import (
 	"github.com/kolide/kolide-ose/server/kolide"
 )
 
-func (orm *Datastore) NewPasswordResetRequest(req *kolide.PasswordResetRequest) (*kolide.PasswordResetRequest, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) NewPasswordResetRequest(req *kolide.PasswordResetRequest) (*kolide.PasswordResetRequest, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	req.ID = orm.nextID(req)
-	orm.passwordResets[req.ID] = req
+	req.ID = d.nextID(req)
+	d.passwordResets[req.ID] = req
 	return req, nil
 }
 
-func (orm *Datastore) SavePasswordResetRequest(req *kolide.PasswordResetRequest) error {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) SavePasswordResetRequest(req *kolide.PasswordResetRequest) error {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	if _, ok := orm.passwordResets[req.ID]; !ok {
+	if _, ok := d.passwordResets[req.ID]; !ok {
 		return errors.ErrNotFound
 	}
 
-	orm.passwordResets[req.ID] = req
+	d.passwordResets[req.ID] = req
 	return nil
 }
 
-func (orm *Datastore) DeletePasswordResetRequest(req *kolide.PasswordResetRequest) error {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) DeletePasswordResetRequest(req *kolide.PasswordResetRequest) error {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	if _, ok := orm.passwordResets[req.ID]; !ok {
+	if _, ok := d.passwordResets[req.ID]; !ok {
 		return errors.ErrNotFound
 	}
 
-	delete(orm.passwordResets, req.ID)
+	delete(d.passwordResets, req.ID)
 	return nil
 }
 
-func (orm *Datastore) DeletePasswordResetRequestsForUser(userID uint) error {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) DeletePasswordResetRequestsForUser(userID uint) error {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	for _, pr := range orm.passwordResets {
+	for _, pr := range d.passwordResets {
 		if pr.UserID == userID {
-			delete(orm.passwordResets, pr.ID)
+			delete(d.passwordResets, pr.ID)
 		}
 	}
 	return nil
 }
 
-func (orm *Datastore) FindPassswordResetByID(id uint) (*kolide.PasswordResetRequest, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) FindPassswordResetByID(id uint) (*kolide.PasswordResetRequest, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	if req, ok := orm.passwordResets[id]; ok {
+	if req, ok := d.passwordResets[id]; ok {
 		return req, nil
 	}
 
 	return nil, errors.ErrNotFound
 }
 
-func (orm *Datastore) FindPassswordResetsByUserID(userID uint) ([]*kolide.PasswordResetRequest, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) FindPassswordResetsByUserID(userID uint) ([]*kolide.PasswordResetRequest, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 	resets := make([]*kolide.PasswordResetRequest, 0)
 
-	for _, pr := range orm.passwordResets {
+	for _, pr := range d.passwordResets {
 		if pr.UserID == userID {
 			resets = append(resets, pr)
 		}
@@ -79,11 +79,11 @@ func (orm *Datastore) FindPassswordResetsByUserID(userID uint) ([]*kolide.Passwo
 	return resets, nil
 }
 
-func (orm *Datastore) FindPassswordResetByToken(token string) (*kolide.PasswordResetRequest, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) FindPassswordResetByToken(token string) (*kolide.PasswordResetRequest, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	for _, pr := range orm.passwordResets {
+	for _, pr := range d.passwordResets {
 		if pr.Token == token {
 			return pr, nil
 		}
@@ -92,11 +92,11 @@ func (orm *Datastore) FindPassswordResetByToken(token string) (*kolide.PasswordR
 	return nil, errors.ErrNotFound
 }
 
-func (orm *Datastore) FindPassswordResetByTokenAndUserID(token string, userID uint) (*kolide.PasswordResetRequest, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) FindPassswordResetByTokenAndUserID(token string, userID uint) (*kolide.PasswordResetRequest, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	for _, pr := range orm.passwordResets {
+	for _, pr := range d.passwordResets {
 		if pr.Token == token && pr.UserID == userID {
 			return pr, nil
 		}

--- a/server/datastore/inmem/scheduled_queries.go
+++ b/server/datastore/inmem/scheduled_queries.go
@@ -7,64 +7,64 @@ import (
 	"github.com/kolide/kolide-ose/server/kolide"
 )
 
-func (orm *Datastore) NewScheduledQuery(sq *kolide.ScheduledQuery) (*kolide.ScheduledQuery, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) NewScheduledQuery(sq *kolide.ScheduledQuery) (*kolide.ScheduledQuery, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
 	newScheduledQuery := *sq
 
-	newScheduledQuery.ID = orm.nextID(newScheduledQuery)
-	orm.scheduledQueries[newScheduledQuery.ID] = &newScheduledQuery
+	newScheduledQuery.ID = d.nextID(newScheduledQuery)
+	d.scheduledQueries[newScheduledQuery.ID] = &newScheduledQuery
 
 	return &newScheduledQuery, nil
 }
 
-func (orm *Datastore) SaveScheduledQuery(sq *kolide.ScheduledQuery) (*kolide.ScheduledQuery, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) SaveScheduledQuery(sq *kolide.ScheduledQuery) (*kolide.ScheduledQuery, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	if _, ok := orm.scheduledQueries[sq.ID]; !ok {
+	if _, ok := d.scheduledQueries[sq.ID]; !ok {
 		return nil, errors.ErrNotFound
 	}
 
-	orm.scheduledQueries[sq.ID] = sq
+	d.scheduledQueries[sq.ID] = sq
 	return sq, nil
 }
 
-func (orm *Datastore) DeleteScheduledQuery(id uint) error {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) DeleteScheduledQuery(id uint) error {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	if _, ok := orm.scheduledQueries[id]; !ok {
+	if _, ok := d.scheduledQueries[id]; !ok {
 		return errors.ErrNotFound
 	}
 
-	delete(orm.scheduledQueries, id)
+	delete(d.scheduledQueries, id)
 	return nil
 }
 
-func (orm *Datastore) ScheduledQuery(id uint) (*kolide.ScheduledQuery, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) ScheduledQuery(id uint) (*kolide.ScheduledQuery, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	sq, ok := orm.scheduledQueries[id]
+	sq, ok := d.scheduledQueries[id]
 	if !ok {
 		return nil, errors.ErrNotFound
 	}
 
-	sq.Name = orm.queries[sq.QueryID].Name
-	sq.Query = orm.queries[sq.QueryID].Query
+	sq.Name = d.queries[sq.QueryID].Name
+	sq.Query = d.queries[sq.QueryID].Query
 
 	return sq, nil
 }
 
-func (orm *Datastore) ListScheduledQueriesInPack(id uint, opt kolide.ListOptions) ([]*kolide.ScheduledQuery, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) ListScheduledQueriesInPack(id uint, opt kolide.ListOptions) ([]*kolide.ScheduledQuery, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
 	// We need to sort by keys to provide reliable ordering
 	keys := []int{}
-	for k, sq := range orm.scheduledQueries {
+	for k, sq := range d.scheduledQueries {
 		if sq.PackID == id {
 			keys = append(keys, int(k))
 		}
@@ -78,9 +78,9 @@ func (orm *Datastore) ListScheduledQueriesInPack(id uint, opt kolide.ListOptions
 
 	scheduledQueries := []*kolide.ScheduledQuery{}
 	for _, k := range keys {
-		q := orm.scheduledQueries[uint(k)]
-		q.Name = orm.queries[q.QueryID].Name
-		q.Query = orm.queries[q.QueryID].Query
+		q := d.scheduledQueries[uint(k)]
+		q.Name = d.queries[q.QueryID].Name
+		q.Query = d.queries[q.QueryID].Query
 		scheduledQueries = append(scheduledQueries, q)
 	}
 
@@ -104,7 +104,7 @@ func (orm *Datastore) ListScheduledQueriesInPack(id uint, opt kolide.ListOptions
 	}
 
 	// Apply limit/offset
-	low, high := orm.getLimitOffsetSliceBounds(opt, len(scheduledQueries))
+	low, high := d.getLimitOffsetSliceBounds(opt, len(scheduledQueries))
 	scheduledQueries = scheduledQueries[low:high]
 
 	return scheduledQueries, nil

--- a/server/datastore/inmem/users.go
+++ b/server/datastore/inmem/users.go
@@ -7,27 +7,27 @@ import (
 	"github.com/kolide/kolide-ose/server/kolide"
 )
 
-func (orm *Datastore) NewUser(user *kolide.User) (*kolide.User, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) NewUser(user *kolide.User) (*kolide.User, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	for _, in := range orm.users {
+	for _, in := range d.users {
 		if in.Username == user.Username {
 			return nil, errors.ErrExists
 		}
 	}
 
-	user.ID = orm.nextID(user)
-	orm.users[user.ID] = user
+	user.ID = d.nextID(user)
+	d.users[user.ID] = user
 
 	return user, nil
 }
 
-func (orm *Datastore) User(username string) (*kolide.User, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) User(username string) (*kolide.User, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	for _, user := range orm.users {
+	for _, user := range d.users {
 		if user.Username == username {
 			return user, nil
 		}
@@ -36,20 +36,20 @@ func (orm *Datastore) User(username string) (*kolide.User, error) {
 	return nil, errors.ErrNotFound
 }
 
-func (orm *Datastore) ListUsers(opt kolide.ListOptions) ([]*kolide.User, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) ListUsers(opt kolide.ListOptions) ([]*kolide.User, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
 	// We need to sort by keys to provide reliable ordering
 	keys := []int{}
-	for k, _ := range orm.users {
+	for k, _ := range d.users {
 		keys = append(keys, int(k))
 	}
 	sort.Ints(keys)
 
 	users := []*kolide.User{}
 	for _, k := range keys {
-		users = append(users, orm.users[uint(k)])
+		users = append(users, d.users[uint(k)])
 	}
 
 	// Apply ordering
@@ -71,17 +71,17 @@ func (orm *Datastore) ListUsers(opt kolide.ListOptions) ([]*kolide.User, error) 
 	}
 
 	// Apply limit/offset
-	low, high := orm.getLimitOffsetSliceBounds(opt, len(users))
+	low, high := d.getLimitOffsetSliceBounds(opt, len(users))
 	users = users[low:high]
 
 	return users, nil
 }
 
-func (orm *Datastore) UserByEmail(email string) (*kolide.User, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) UserByEmail(email string) (*kolide.User, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	for _, user := range orm.users {
+	for _, user := range d.users {
 		if user.Email == email {
 			return user, nil
 		}
@@ -90,25 +90,25 @@ func (orm *Datastore) UserByEmail(email string) (*kolide.User, error) {
 	return nil, errors.ErrNotFound
 }
 
-func (orm *Datastore) UserByID(id uint) (*kolide.User, error) {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) UserByID(id uint) (*kolide.User, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	if user, ok := orm.users[id]; ok {
+	if user, ok := d.users[id]; ok {
 		return user, nil
 	}
 
 	return nil, errors.ErrNotFound
 }
 
-func (orm *Datastore) SaveUser(user *kolide.User) error {
-	orm.mtx.Lock()
-	defer orm.mtx.Unlock()
+func (d *Datastore) SaveUser(user *kolide.User) error {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
-	if _, ok := orm.users[user.ID]; !ok {
+	if _, ok := d.users[user.ID]; !ok {
 		return errors.ErrNotFound
 	}
 
-	orm.users[user.ID] = user
+	d.users[user.ID] = user
 	return nil
 }


### PR DESCRIPTION
This makes the inmem method receiver naming consistent with mysql. It also
eliminates potential confusion with the phrase "orm".