### PR TITLE
don't drop tables in prepare db step

### DIFF
--- a/cli/prepare.go
+++ b/cli/prepare.go
@@ -40,10 +40,6 @@ To setup kolide infrastructure, use one of the available commands.
 				initFatal(err, "creating db connection")
 			}
 
-			if err := ds.Drop(); err != nil {
-				initFatal(err, "dropping db tables")
-			}
-
 			if err := ds.Migrate(); err != nil {
 				initFatal(err, "migrating db schema")
 			}


### PR DESCRIPTION
I'm not sure what the intention here is, but I nuked the test database by mistake because I used `prepare db`  ¯\\\_(ツ)_/¯