### PR TITLE
Use org logo url

### DIFF
--- a/frontend/components/icons/OrgLogoIcon/OrgLogoIcon.jsx
+++ b/frontend/components/icons/OrgLogoIcon/OrgLogoIcon.jsx
@@ -4,6 +4,7 @@ import kolideLogo from '../../../../assets/images/kolide-logo.svg';
 
 class OrgLogoIcon extends Component {
   static propTypes = {
+    className: PropTypes.string,
     src: PropTypes.string.isRequired,
   };
 
@@ -40,12 +41,14 @@ class OrgLogoIcon extends Component {
   }
 
   render () {
+    const { className } = this.props;
     const { imageSrc } = this.state;
     const { onError } = this;
 
     return (
       <img
         alt="Organization Logo"
+        className={className}
         onError={onError}
         src={imageSrc}
       />

--- a/frontend/components/side_panels/SiteNavHeader/SiteNavHeader.jsx
+++ b/frontend/components/side_panels/SiteNavHeader/SiteNavHeader.jsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 
 import configInterface from 'interfaces/config';
 import Icon from 'components/icons/Icon';
+import OrgLogoIcon from 'components/icons/OrgLogoIcon';
 import userInterface from 'interfaces/user';
 import UserMenu from 'components/side_panels/SiteNavHeader/UserMenu';
 
@@ -86,11 +87,7 @@ class SiteNavHeader extends Component {
       <header className={headerBaseClass}>
         <button className={headerToggleClass} onClick={toggleUserMenu} ref={setHeaderNav}>
           <div className={`${headerBaseClass}__org`}>
-            <img
-              alt="Company logo"
-              src={orgLogoURL}
-              className={`${headerBaseClass}__logo`}
-            />
+            <OrgLogoIcon className={`${headerBaseClass}__logo`} src={orgLogoURL} />
             <h1 className={`${headerBaseClass}__org-name`}>{orgName}</h1>
             <div className={userStatusClass} />
             <h2 className={`${headerBaseClass}__username`}>{username}</h2>


### PR DESCRIPTION
Follow up to #685 

Since we have an org's logo url now, this PR changes the site nav header to use the url instead of hardcoding the kolide logo.