### PR TITLE
Making the dev mode text a little prettier

### DIFF
--- a/cli/serve.go
+++ b/cli/serve.go
@@ -63,9 +63,15 @@ the way that the kolide server works.
 			var mailService kolide.MailService
 
 			if devMode {
-				fmt.Println(
-					"Dev mode enabled, using in-memory DB.\n",
-					"Warning: Changes will not be saved across process restarts. This should NOT be used in production.",
+				fmt.Print(
+					"********************************************************************************\n",
+					"* Warning:                                                                     *\n",
+					"*                                                                              *\n",
+					"*    Developer mode is currently enabled, so Kolide is using a transient,      *\n",
+					"*    in-memory DB. Any changes you make to the database will not be saved      *\n",
+					"*    across process restarts. This should NOT be used in production.           *\n",
+					"*                                                                              *\n",
+					"********************************************************************************\n",
 				)
 
 				if ds, err = inmem.New(config); err != nil {


### PR DESCRIPTION
This is a silly PR, but I had it left over in a branch from last night.

## The way it looks now

```
> .\build\kolide.exe serve --dev
Dev mode enabled, using in-memory DB.
 Warning: Changes will not be saved across process restarts. This should NOT be used in production.
ts=2016-12-21T06:57:05Z transport=http address=:8080 msg=listening
```

## The way it looks in this PR

```
> .\build\kolide.exe serve --dev
********************************************************************************
* Warning:                                                                     *
*                                                                              *
*    Developer mode is currently enabled, so Kolide is using a transient,      *
*    in-memory DB. Any changes you make to the database will not be saved      *
*    across process restarts. This should NOT be used in production.           *
*                                                                              *
********************************************************************************
ts=2016-12-22T18:04:53Z transport=http address=:8080 msg=listening
```