### PR TITLE
add error logging to distributed query campaign handler

### DIFF
--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -271,7 +271,7 @@ func MakeHandler(ctx context.Context, svc kolide.Service, jwtKey string, logger 
 	r := mux.NewRouter()
 	attachKolideAPIRoutes(r, kolideHandlers)
 	r.HandleFunc("/api/v1/kolide/results/{id}",
-		makeStreamDistributedQueryCampaignResultsHandler(svc, jwtKey)).
+		makeStreamDistributedQueryCampaignResultsHandler(svc, jwtKey, logger)).
 		Methods("GET").Name("distributed_query_results")
 
 	addMetrics(r)


### PR DESCRIPTION
I added some error handling to the method which creates the websocket handler. 

I think error handing is important, but I'm not sure logging them is the best approach. let's discuss!