### PR TITLE
use entityID when deleting invite

### DIFF
--- a/frontend/pages/Admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/Admin/UserManagementPage/UserManagementPage.jsx
@@ -84,7 +84,7 @@ class UserManagementPage extends Component {
               return dispatch(renderFlash('success', 'User forced to reset password', update(user, { force_password_reset: false })));
             });
         case 'revert_invitation':
-          return dispatch(inviteActions.destroy(user))
+          return dispatch(inviteActions.destroy({ entityID: user.id }))
             .then(() => {
               return dispatch(renderFlash('success', 'Invite revoked'));
             });


### PR DESCRIPTION
Fixes #696
Regression from 8567cc458c0cc5399d65f020782d521a4ceeb636


---

@mikestone14 you submitted some Go, so I thought I'd poke at JS today. 

Question: Why is the entity id `user.id` and not `invite.id`? 
I also noticed the following issue:
1) The flash message shows success, even when the backend returns an error.
2) Revoking an invite successfully does not appear to remove the invitee card from view. 