### PR TITLE
always print email messages in dev mode

### DIFF
--- a/server/mail/mail.go
+++ b/server/mail/mail.go
@@ -55,20 +55,10 @@ func getMessageBody(e kolide.Email) ([]byte, error) {
 }
 
 func (dm devMailService) SendEmail(e kolide.Email) error {
-	if !e.Config.SMTPEnabled {
-		return fmt.Errorf("email disabled")
+	msg, err := getMessageBody(e)
+	if err != nil {
+		return err
 	}
-	if e.Config.SMTPConfigured {
-		msg, err := getMessageBody(e)
-		if err != nil {
-			return err
-		}
-		fmt.Printf(string(msg))
-	}
-	return nil
-}
-
-func (dm devMailService) sendMail(e kolide.Email, msg []byte) error {
 	fmt.Println(string(msg))
 	return nil
 }


### PR DESCRIPTION
I believe the intended behavior for devMode should be to always print the intended message to stdout, regardless of SMTP config. 

My reasoning is that `--dev` should only run for the purpose of testing/demoing the app and should require no external configuration. 

@murphybytes please review when you have a chance. 