### PR TITLE
Add invite email template and use the new invite mailer pattern

### DIFF
--- a/server/datastore/inmem/inmem.go
+++ b/server/datastore/inmem/inmem.go
@@ -511,6 +511,7 @@ func (d *Datastore) createDevHosts() error {
 
 func (d *Datastore) createDevOrgInfo() error {
 	devOrgInfo := &kolide.AppConfig{
+		KolideServerURL:        "http://localhost:8080",
 		OrgName:                "Kolide",
 		OrgLogoURL:             fmt.Sprintf("https://%s/assets/images/kolide-logo.svg", d.config.Server.Address),
 		SMTPPort:               587,

--- a/server/kolide/emails.go
+++ b/server/kolide/emails.go
@@ -68,7 +68,7 @@ func (m *SMTPTestMailer) Message() ([]byte, error) {
 
 type PasswordResetMailer struct {
 	// URL for the Kolide application
-	KolideServerURL string
+	KolideServerURL template.URL
 	// Token password reset token
 	Token string
 }

--- a/server/kolide/invites.go
+++ b/server/kolide/invites.go
@@ -68,20 +68,20 @@ type Invite struct {
 	Token     string `json:"-"`
 }
 
-// TODO: fixme
-// this is not the right way to generate emails at all
-const inviteEmailTempate = `
-{{.InvitedBy}} invited you to join Kolide.,
-http://localhost:8080/signup?token={{.Token}}
-`
+// InviteMailer is used to build an email template for the invite email.
+type InviteMailer struct {
+	*Invite
+	KolideServerURL   template.URL
+	InvitedByUsername string
+}
 
-func (i Invite) Message() ([]byte, error) {
-	var msg bytes.Buffer
-	var err error
-	t := template.New(inviteEmailTempate)
-	if t, err = t.Parse(inviteEmailTempate); err != nil {
+func (i *InviteMailer) Message() ([]byte, error) {
+	t, err := getTemplate("server/mail/templates/invite_token.html")
+	if err != nil {
 		return nil, err
 	}
+
+	var msg bytes.Buffer
 	if err = t.Execute(&msg, i); err != nil {
 		return nil, err
 	}

--- a/server/mail/templates/invite_token.html
+++ b/server/mail/templates/invite_token.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    </head>
+    <title></title>
+    </head>
+    <body>
+        <p>{{.InvitedByUsername}} invited you to join Kolide. Click below to join:</p>
+        <p><a href=
+        "{{.KolideServerURL}}/login/invites/{{.Token}}?name={{.Name}}&email={{.Email}}">Join
+        Kolide</a></p>
+    </body>
+</html>

--- a/server/service/service_invites.go
+++ b/server/service/service_invites.go
@@ -2,16 +2,11 @@ package service
 
 import (
 	"encoding/base64"
+	"html/template"
 
 	"github.com/kolide/kolide-ose/server/kolide"
 	"golang.org/x/net/context"
 )
-
-type inviteMailer struct{}
-
-func (m *inviteMailer) Message() ([]byte, error) {
-	return []byte("test message"), nil
-}
 
 func (svc service) InviteNewUser(ctx context.Context, payload kolide.InvitePayload) (*kolide.Invite, error) {
 	// verify that the user with the given email does not already exist
@@ -63,7 +58,11 @@ func (svc service) InviteNewUser(ctx context.Context, payload kolide.InvitePaylo
 		Subject: "You're Invited to Kolide",
 		To:      []string{invite.Email},
 		Config:  config,
-		Mailer:  &inviteMailer{},
+		Mailer: &kolide.InviteMailer{
+			Invite:            invite,
+			KolideServerURL:   template.URL(config.KolideServerURL),
+			InvitedByUsername: inviter.Name,
+		},
 	}
 
 	err = svc.mailService.SendEmail(inviteEmail)

--- a/server/service/service_users.go
+++ b/server/service/service_users.go
@@ -3,6 +3,7 @@ package service
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"html/template"
 	"time"
 
 	"github.com/kolide/kolide-ose/server/contexts/viewer"
@@ -254,7 +255,7 @@ func (svc service) RequestPasswordReset(ctx context.Context, email string) error
 		To:      []string{user.Email},
 		Config:  config,
 		Mailer: &kolide.PasswordResetMailer{
-			KolideServerURL: config.KolideServerURL,
+			KolideServerURL: template.URL(config.KolideServerURL),
 			Token:           token,
 		},
 	}


### PR DESCRIPTION
Closes #693
Closes #581 


Note that I had to change the KolideServerURL to be of the https://golang.org/pkg/html/template/#URL type. The template package automatically escapes any potentially unsafe strings by default.  

There is some duplication around email templates that can/should be cleaned up but that's out of scope for this bugfix PR.  
