### PR TITLE
Redirect frontend routes to setup if setup is not configured.

### DIFF
--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/go-kit/kit/endpoint"
@@ -358,7 +357,6 @@ func attachKolideAPIRoutes(r *mux.Router, h *kolideHandlers) {
 func WithSetup(svc kolide.Service, logger kitlog.Logger, next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		configRouter := http.NewServeMux()
-		configRouter.Handle("/api/v1/kolide/config", http.HandlerFunc(forceSetup))
 		configRouter.Handle("/api/v1/setup", kithttp.NewServer(
 			context.Background(),
 			makeSetupEndpoint(svc),
@@ -373,12 +371,24 @@ func WithSetup(svc kolide.Service, logger kitlog.Logger, next http.Handler) http
 	}
 }
 
-func forceSetup(w http.ResponseWriter, r *http.Request) {
-	response := map[string]bool{
-		"require_setup": true,
-	}
-	if err := json.NewEncoder(w).Encode(&response); err != nil {
-		encodeError(context.Background(), err, w)
+// RedirectLoginToSetup detects if the setup endpoint should be used. If setup is required it redirect all
+// frontend urls to /setup, otherwise the frontend router is used.
+func RedirectLoginToSetup(svc kolide.Service, logger kitlog.Logger, next http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		redirect := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/setup" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			newURL := r.URL
+			newURL.Path = "/setup"
+			http.Redirect(w, r, newURL.String(), http.StatusTemporaryRedirect)
+		})
+		if RequireSetup(svc, logger) {
+			redirect.ServeHTTP(w, r)
+		} else {
+			next.ServeHTTP(w, r)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #617 

This PR routes the frontend paths through a middleware that redirects frontend routes to `/setup` if needed. 
While setup is required only the backend and frontend setup endpoints are available. 
Once setup is configured, routes behave as usual. 

@mikestone14 @zwass I'd like to get approval from both of you on this strategy. 