### PR TITLE
Only re-render the org logo when src is changed

### DIFF
--- a/frontend/components/icons/OrgLogoIcon/OrgLogoIcon.jsx
+++ b/frontend/components/icons/OrgLogoIcon/OrgLogoIcon.jsx
@@ -28,16 +28,39 @@ class OrgLogoIcon extends Component {
 
   componentWillReceiveProps (nextProps) {
     const { src } = nextProps;
+    const { unchangedSourceProp } = this;
+
+    if (unchangedSourceProp(nextProps)) {
+      return false;
+    }
 
     this.setState({ imageSrc: src });
 
     return false;
   }
 
+  shouldComponentUpdate (nextProps) {
+    const { imageSrc } = this.state;
+    const { unchangedSourceProp } = this;
+
+    if (unchangedSourceProp(nextProps) && (imageSrc === kolideLogo)) {
+      return false;
+    }
+
+    return true;
+  }
+
   onError = () => {
     this.setState({ imageSrc: kolideLogo });
 
     return false;
+  }
+
+  unchangedSourceProp = (nextProps) => {
+    const { src: nextSrcProp } = nextProps;
+    const { src } = this.props;
+
+    return src === nextSrcProp;
   }
 
   render () {


### PR DESCRIPTION
When the org logo URL in the app config is not a valid image source we were running into an issue of the component re-rendering when any action was taken. This was happening because we are changing the state of the component if the image source errors (and setting the source to a default image). Since the source was invalid we were trying to change the source and then error-ing and re-setting the default source on every click.

This PR prevents the component from re-rendering unless the image src changes.

closes #777 