### PR TITLE
Correctly sets the user’s role in user settings page

### DIFF
--- a/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
+++ b/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
@@ -15,7 +15,7 @@ import UserSettingsForm from 'components/forms/UserSettingsForm';
 
 const baseClass = 'user-settings';
 
-class UserSettingsPage extends Component {
+export class UserSettingsPage extends Component {
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
     errors: PropTypes.shape({
@@ -116,7 +116,8 @@ class UserSettingsPage extends Component {
       return false;
     }
 
-    const { updated_at: updatedAt } = user;
+    const { admin, updated_at: updatedAt } = user;
+    const roleText = admin ? 'ADMIN' : 'USER';
     const lastUpdatedAt = moment(updatedAt).fromNow();
 
     return (
@@ -140,7 +141,7 @@ class UserSettingsPage extends Component {
 
           <div className={`${baseClass}__more-info-detail`}>
             <Icon name="username" />
-            <strong>Role</strong> - USER
+            <strong>Role</strong> - {roleText}
           </div>
           <div className={`${baseClass}__more-info-detail`}>
             <Icon name="lock-big" />

--- a/frontend/pages/UserSettingsPage/UserSettingsPage.tests.jsx
+++ b/frontend/pages/UserSettingsPage/UserSettingsPage.tests.jsx
@@ -1,7 +1,9 @@
+import React from 'react';
 import expect from 'expect';
 import { mount } from 'enzyme';
+import { noop } from 'lodash';
 
-import ConnectedPage from 'pages/UserSettingsPage';
+import ConnectedPage, { UserSettingsPage } from 'pages/UserSettingsPage/UserSettingsPage';
 import testHelpers from 'test/helpers';
 import { userStub } from 'test/stubs';
 
@@ -15,5 +17,16 @@ describe('UserSettingsPage - component', () => {
     const page = mount(connectedComponent(ConnectedPage, { mockStore }));
 
     expect(page.find('UserSettingsForm').length).toEqual(1);
+  });
+
+  it('renders a UserSettingsForm component', () => {
+    const admin = { ...userStub, admin: true };
+    const pageWithUser = mount(<UserSettingsPage dispatch={noop} user={userStub} />);
+    const pageWithAdmin = mount(<UserSettingsPage dispatch={noop} user={admin} />);
+
+    expect(pageWithUser.text()).toInclude('Role - USER');
+    expect(pageWithUser.text()).toNotInclude('Role - ADMIN');
+    expect(pageWithAdmin.text()).toNotInclude('Role - USER');
+    expect(pageWithAdmin.text()).toInclude('Role - ADMIN');
   });
 });


### PR DESCRIPTION
closes #783 

This PR updates the side panel in the user settings page to correctly set the role of a user as "USER" or "ADMIN".