### PR TITLE
Fix logout bug on Safari

### DIFF
--- a/frontend/kolide/base.js
+++ b/frontend/kolide/base.js
@@ -80,7 +80,7 @@ class Base {
     return this._authenticatedRequest(PATCH, endpoint, body, overrideHeaders);
   }
 
-  authenticatedPost (endpoint, body = {}, overrideHeaders = {}) {
+  authenticatedPost (endpoint, body = JSON.stringify({}), overrideHeaders = {}) {
     const { POST } = REQUEST_METHODS;
 
     return this._authenticatedRequest(POST, endpoint, body, overrideHeaders);


### PR DESCRIPTION
I was checking out #786 on Safari and tried to log out as the admin user and log in as the regular user. I was not able to log out on Safari but Chrome worked fine. Looking into it I discovered that we're not correctly sending over a JSON body for the logout request (or any similar post requests with an empty body). This PR conversation the default empty body object to JSON to make the request valid.