### PR TITLE
Adding the display_text attribute to the hosts API

### DIFF
--- a/server/service/endpoint_hosts.go
+++ b/server/service/endpoint_hosts.go
@@ -79,14 +79,14 @@ func makeListHostsEndpoint(svc kolide.Service) endpoint.Endpoint {
 			return listHostsResponse{Err: err}, nil
 		}
 
-		var hostResponses []hostResponse
-		for _, host := range hosts {
+		hostResponses := make([]hostResponse, len(hosts), len(hosts))
+		for i, host := range hosts {
 			h, err := hostResponseForHost(ctx, svc, host)
 			if err != nil {
 				return listHostsResponse{Err: err}, nil
 			}
 
-			hostResponses = append(hostResponses, *h)
+			hostResponses[i] = *h
 		}
 		return listHostsResponse{Hosts: hostResponses}, nil
 	}


### PR DESCRIPTION
This adds the `display_text` attribute to the hosts API via a shared helper for `hostResponse` that follows the same signature as `packResponse` and `packResponseForPack`. I'm not sure that this is the best signature, and it's currently not required by `hostResponseForHost`, but if we ever have to call service methods on the host to populate it's response similarly to how we do on packs, they may be necessary.

close #832