### PR TITLE
add the error message to DatabaseError

### DIFF
--- a/server/errors/errors.go
+++ b/server/errors/errors.go
@@ -55,7 +55,7 @@ func NewFromError(err error, status int, publicMessage string) *KolideError {
 
 // Wrap a DB error with the extra KolideError decorations
 func DatabaseError(err error) *KolideError {
-	return NewFromError(err, http.StatusInternalServerError, "Database error")
+	return NewFromError(err, http.StatusInternalServerError, "Database error: "+err.Error())
 }
 
 // Wrap a server error with the extra KolideError decorations

--- a/server/errors/errors_test.go
+++ b/server/errors/errors_test.go
@@ -54,7 +54,7 @@ func TestDatabaseError(t *testing.T) {
 	expect := &KolideError{
 		Err:            err,
 		StatusCode:     http.StatusInternalServerError,
-		PublicMessage:  "Database error",
+		PublicMessage:  "Database error: " + err.Error(),
 		PrivateMessage: "Foo error",
 	}
 	assert.Equal(t, expect, kolideErr)


### PR DESCRIPTION
We're slowly refactoring the remaining bits of KolideError in the datastore package. But until then, this adds the error message from the originally suppressed error from mysql.  