### PR TITLE
Fix failing Redis query results test

### DIFF
--- a/server/pubsub/query_results_test.go
+++ b/server/pubsub/query_results_test.go
@@ -141,6 +141,7 @@ func testQueryResultsStore(t *testing.T, store kolide.QueryResultStore) {
 				},
 
 				DetailUpdateTime: time.Now().UTC(),
+				SeenTime:         time.Now().UTC(),
 			},
 		},
 		kolide.DistributedQueryResult{
@@ -158,6 +159,7 @@ func testQueryResultsStore(t *testing.T, store kolide.QueryResultStore) {
 				},
 
 				DetailUpdateTime: time.Now().UTC(),
+				SeenTime:         time.Now().UTC(),
 			},
 		},
 		kolide.DistributedQueryResult{
@@ -175,6 +177,7 @@ func testQueryResultsStore(t *testing.T, store kolide.QueryResultStore) {
 				},
 
 				DetailUpdateTime: time.Now().UTC(),
+				SeenTime:         time.Now().UTC(),
 			},
 		},
 	}
@@ -201,6 +204,7 @@ func testQueryResultsStore(t *testing.T, store kolide.QueryResultStore) {
 				},
 
 				DetailUpdateTime: time.Now().UTC(),
+				SeenTime:         time.Now().UTC(),
 			},
 		},
 		kolide.DistributedQueryResult{
@@ -218,6 +222,7 @@ func testQueryResultsStore(t *testing.T, store kolide.QueryResultStore) {
 				},
 
 				DetailUpdateTime: time.Now().UTC(),
+				SeenTime:         time.Now().UTC(),
 			},
 		},
 	}


### PR DESCRIPTION
Due to the timezone being changed on time.Time's zero value after a roundtrip
serialization, any times being compared in this test must be explicitly set.