### PR TITLE
Fix result log struct to support snapshot logs

### DIFF
--- a/server/kolide/osquery.go
+++ b/server/kolide/osquery.go
@@ -1,8 +1,6 @@
 package kolide
 
-import (
-	"golang.org/x/net/context"
-)
+import "golang.org/x/net/context"
 
 type OsqueryService interface {
 	EnrollAgent(ctx context.Context, enrollSecret, hostIdentifier string) (nodeKey string, err error)
@@ -52,13 +50,16 @@ type OsqueryConfig struct {
 }
 
 type OsqueryResultLog struct {
-	Name           string            `json:"name"`
-	HostIdentifier string            `json:"hostIdentifier"`
-	UnixTime       string            `json:"unixTime"`
-	CalendarTime   string            `json:"calendarTime"`
-	Columns        map[string]string `json:"columns"`
-	Action         string            `json:"action"`
-	Decorations    map[string]string `json:"decorations"`
+	Name           string `json:"name"`
+	HostIdentifier string `json:"hostIdentifier"`
+	UnixTime       string `json:"unixTime"`
+	CalendarTime   string `json:"calendarTime"`
+	// Columns stores the columns of differential queries
+	Columns map[string]string `json:"columns,omitempty"`
+	// Snapshot stores the rows and columns of snapshot queries
+	Snapshot    []map[string]string `json:"snapshot,omitempty"`
+	Action      string              `json:"action"`
+	Decorations map[string]string   `json:"decorations"`
 }
 
 type OsqueryStatusLog struct {

--- a/server/service/service_osquery_test.go
+++ b/server/service/service_osquery_test.go
@@ -175,6 +175,7 @@ func TestSubmitResultLogs(t *testing.T) {
 	logs := []string{
 		`{"name":"system_info","hostIdentifier":"some_uuid","calendarTime":"Fri Sep 30 17:55:15 2016 UTC","unixTime":"1475258115","decorations":{"host_uuid":"some_uuid","username":"zwass"},"columns":{"cpu_brand":"Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz","hostname":"hostimus","physical_memory":"17179869184"},"action":"added"}`,
 		`{"name":"encrypted","hostIdentifier":"some_uuid","calendarTime":"Fri Sep 30 21:19:15 2016 UTC","unixTime":"1475270355","decorations":{"host_uuid":"4740D59F-699E-5B29-960B-979AAF9BBEEB","username":"zwass"},"columns":{"encrypted":"1","name":"\/dev\/disk1","type":"AES-XTS","uid":"","user_uuid":"","uuid":"some_uuid"},"action":"added"}`,
+		`{"snapshot":[{"hour":"20","minutes":"8"}],"action":"snapshot","name":"time","hostIdentifier":"1379f59d98f4","calendarTime":"Tue Jan 10 20:08:51 2017 UTC","unixTime":"1484078931","decorations":{"host_uuid":"EB714C9D-C1F8-A436-B6DA-3F853C5502EA"}}`,
 	}
 	logJSON := fmt.Sprintf("[%s]", strings.Join(logs, ","))
 


### PR DESCRIPTION
Snapshot logs have a different schema, and are now (un)serialized correctly.

Fixes #841 