### PR TITLE
Annotate osquery logs with host information

### DIFF
--- a/server/kolide/hosts.go
+++ b/server/kolide/hosts.go
@@ -126,6 +126,20 @@ func (h *Host) ResetPrimaryNetwork() bool {
 
 }
 
+func (h *Host) PrimaryNetworkInterface() *NetworkInterface {
+	if h.PrimaryNetworkInterfaceID == nil {
+		return nil
+	}
+
+	for _, ni := range h.NetworkInterfaces {
+		if ni.ID == *h.PrimaryNetworkInterfaceID {
+			return ni
+		}
+	}
+
+	return nil
+}
+
 // RandomText returns a stdEncoded string of
 // just what it says
 func RandomText(keySize int) (string, error) {


### PR DESCRIPTION
Changes the format of output status and result logs to include identifying
information about the host.

Previous output example:
```
{
  "severity":"0",
  "filename":"smbios_tables.cpp",
  "line":"103",
  "message":"Reading SMBIOS from sysfs DMI node",
  "version":"2.1.2",
  "decorations":{
    "host_uuid":"EB714C9D-C1F8-A436-B6DA-3F853C5502EA"
  }
}
```

New annotated output:
```
{
  "log":{
    "severity":"0",
    "filename":"smbios_tables.cpp",
    "line":"103",
    "message":"Reading SMBIOS from sysfs DMI node",
    "version":"2.1.2",
    "decorations":{
      "host_uuid":"EB714C9D-C1F8-A436-B6DA-3F853C5502EA"
    }
  },
  "host":{
    "hostname":"e5bd558309f0",
    "primary_ip":"172.19.0.2",
    "uuid":"EB714C9D-C1F8-A436-B6DA-3F853C5502EA"
  }
}
```