### PR TITLE
Use a different MySQL database for tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,18 @@ services:
     ports:
       - "3306:3306"
 
+  mysql-test:
+    image: mysql:5.7
+    command: mysqld --datadir=/tmpfs
+    tmpfs: /tmpfs
+    environment:
+      MYSQL_ROOT_PASSWORD: toor
+      MYSQL_DATABASE: kolide
+      MYSQL_USER: kolide
+      MYSQL_PASSWORD: kolide
+    ports:
+      - "3307:3306"
+
   mailhog:
     image: mailhog/mailhog:latest
     ports:

--- a/server/datastore/mysql_test.go
+++ b/server/datastore/mysql_test.go
@@ -17,11 +17,11 @@ func setupMySQL(t *testing.T) (ds *mysql.Datastore, teardown func()) {
 		Username: "kolide",
 		Password: "kolide",
 		Database: "kolide",
-		Address:  "127.0.0.1:3306",
+		Address:  "127.0.0.1:3307",
 	}
 
 	if h, ok := os.LookupEnv("MYSQL_PORT_3306_TCP_ADDR"); ok {
-		config.Address = h + ":3306"
+		config.Address = h + ":3307"
 	}
 
 	ds, err := mysql.New(config, clock.NewMockClock(), mysql.Logger(log.NewNopLogger()), mysql.LimitAttempts(1))


### PR DESCRIPTION
If you're using MySQL as the application database, running the tests drops all of your tables. This PR adds another mysql container just for tests.