### PR TITLE
always return a mail error if sending mail failed

### DIFF
--- a/server/service/service_appconfig.go
+++ b/server/service/service_appconfig.go
@@ -78,12 +78,8 @@ func (svc service) ModifyAppConfig(ctx context.Context, p kolide.AppConfigPayloa
 			if err != nil {
 				// if there is an error, set configured to false
 				newConfig.SMTPConfigured = false
-
-				if smtpTest {
-					// if we're sending a test email, return: the test failed
-					return nil, mailError{
-						message: err.Error(),
-					}
+				return nil, mailError{
+					message: err.Error(),
 				}
 			} else {
 				// if there was not an error sending the test email, set


### PR DESCRIPTION
I believe this is the correct behavior. otherwise the configuration fails to save and you never know why, even with a 200 OK response. 