### PR TITLE
add middleware to redirect setup to login if the app has an admin

### DIFF
--- a/cli/serve.go
+++ b/cli/serve.go
@@ -143,6 +143,8 @@ the way that the kolide server works.
 				if service.RequireSetup(svc, logger) {
 					apiHandler = service.WithSetup(svc, logger, apiHandler)
 					frontendHandler = service.RedirectLoginToSetup(svc, logger, frontendHandler)
+				} else {
+					frontendHandler = service.RedirectSetupToLogin(svc, logger, frontendHandler)
 				}
 			}
 

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -405,7 +405,7 @@ func RedirectLoginToSetup(svc kolide.Service, logger kitlog.Logger, next http.Ha
 		if RequireSetup(svc, logger) {
 			redirect.ServeHTTP(w, r)
 		} else {
-			next.ServeHTTP(w, r)
+			RedirectSetupToLogin(svc, logger, next).ServeHTTP(w, r)
 		}
 	}
 }
@@ -418,4 +418,18 @@ func RequireSetup(svc kolide.Service, logger kitlog.Logger) bool {
 		return false
 	}
 	return len(users) == 0
+}
+
+// RedirectSetupToLogin forces the /setup path to be redirected to login. This middleware is used after
+// the app has been setup.
+func RedirectSetupToLogin(svc kolide.Service, logger kitlog.Logger, next http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/setup" {
+			newURL := r.URL
+			newURL.Path = "/login"
+			http.Redirect(w, r, newURL.String(), http.StatusTemporaryRedirect)
+			return
+		}
+		next.ServeHTTP(w, r)
+	}
 }


### PR DESCRIPTION
If the app setup is complete, we force /setup to redirect to /login

Fixes https://github.com/kolide/kolide-ose/issues/893

@terracatta you'd have to test this locally with a new mysql. I tried it and it appears to be doing exactly what it should. 

