### PR TITLE
Revert "Add some basic decorators to the osquery config (#875)"

### DIFF
--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -73,15 +73,7 @@ func (svc service) GetClientConfig(ctx context.Context) (*kolide.OsqueryConfig, 
 
 	config := &kolide.OsqueryConfig{
 		Options: options,
-		Decorators: kolide.Decorators{
-			Interval: map[string][]string{
-				"3600": []string{
-					"SELECT uuid AS host_uuid FROM system_info;",
-					"SELECT hostname FROM system_info;",
-				},
-			},
-		},
-		Packs: kolide.Packs{},
+		Packs:   kolide.Packs{},
 	}
 
 	packs, err := svc.ListPacksForHost(ctx, host.ID)


### PR DESCRIPTION
This reverts commit 1d029073e5730fc43a20573905ad27a685509b07.

close #928