### PR TITLE
remove binaryFilesystem wrapper from bindata files

### DIFF
--- a/server/service/frontend.go
+++ b/server/service/frontend.go
@@ -4,37 +4,16 @@ import (
 	"html/template"
 	"io/ioutil"
 	"net/http"
-	"strings"
 
 	assetfs "github.com/elazarl/go-bindata-assetfs"
 )
 
-type binaryFileSystem struct {
-	fs *assetfs.AssetFS
-}
-
-func (b *binaryFileSystem) Open(name string) (http.File, error) {
-	return b.fs.Open(name)
-}
-
-func (b *binaryFileSystem) Exists(prefix string, filepath string) bool {
-	if p := strings.TrimPrefix(filepath, prefix); len(p) < len(filepath) {
-		if _, err := b.fs.Open(p); err != nil {
-			return false
-		}
-		return true
-	}
-	return false
-}
-
-func newBinaryFileSystem(root string) *binaryFileSystem {
-	return &binaryFileSystem{
-		fs: &assetfs.AssetFS{
-			Asset:     Asset,
-			AssetDir:  AssetDir,
-			AssetInfo: AssetInfo,
-			Prefix:    root,
-		},
+func newBinaryFileSystem(root string) *assetfs.AssetFS {
+	return &assetfs.AssetFS{
+		Asset:     Asset,
+		AssetDir:  AssetDir,
+		AssetInfo: AssetInfo,
+		Prefix:    root,
 	}
 }
 


### PR DESCRIPTION
While looking into caching issues I ended up reviewing this code and the wrapper was not used anywhere in the codebase. I removed it. 