### PR TITLE
Changed query columns to TEXT type

### DIFF
--- a/server/datastore/mysql/migrations/tables/20170117025759_IncreaseQueryLength.go
+++ b/server/datastore/mysql/migrations/tables/20170117025759_IncreaseQueryLength.go
@@ -1,0 +1,53 @@
+package tables
+
+import (
+	"database/sql"
+)
+
+func init() {
+	MigrationClient.AddMigration(Up_20170117025759, Down_20170117025759)
+}
+
+func Up_20170117025759(tx *sql.Tx) error {
+	_, err := tx.Exec(
+		"ALTER TABLE `decorators` MODIFY `query` TEXT NOT NULL;",
+	)
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(
+		"ALTER TABLE `queries` MODIFY `query` TEXT NOT NULL;",
+	)
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(
+		"ALTER TABLE `labels` MODIFY `query` TEXT NOT NULL;",
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func Down_20170117025759(tx *sql.Tx) error {
+	_, err := tx.Exec(
+		"ALTER TABLE `decorators` MODIFY `query` VARCHAR(255) NOT NULL;",
+	)
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(
+		"ALTER TABLE `queries` MODIFY `query` VARCHAR(255) NOT NULL;",
+	)
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(
+		"ALTER TABLE `labels` MODIFY `query` VARCHAR(255) NOT NULL;",
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This addresses https://github.com/kolide/kolide-ose/issues/916 where query fields aren't long enough.  Note I changed all the query fields to type TEXT which will allow the user to enter queries pretty much as long as they want.  The max query length for mysql is 4MB but because this is version dependent I think it's better to let the db engine enforce that. 