### PR TITLE
remove dev mode from cli options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@ define HELP_TEXT
 	make lint-scss    - Run the SCSS linters
 	make lint-ts      - Run the TypeScript linters
 
-	make run          - Run the Kolide server in dev mode
 
 endef
 
@@ -150,8 +149,6 @@ else
 	rm -f assets/bundle.js
 endif
 
-run:
-	$(OUTPUT) serve --dev
 
 docker-build-circle:
 	@echo ">> building docker image"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@
     - [Setting up the database tables](#setting-up-the-database-tables)
   - [Running Kolide](#running-kolide)
     - [Using Docker development infrastructure](#using-docker-development-infrastructure)
-    - [Using no external dependencies](#using-no-external-dependencies)
 
 
 ## Development Environment
@@ -396,25 +395,3 @@ instead of `localhost`.There is an example configuration file included in this
 repository to make this process easier for you.  Use the `--config` flag of the
 Kolide binary to specify the path to your config. See `kolide --help` for more
 options.
-
-#### Using no external dependencies
-
-If you'd like to launch the Kolide server with no external dependencies, run
-the following:
-
-```
-kolide serve --dev
-```
-
-This will use in-memory mocks for the database, print emails to the console,
-etc. If you're demo-ing Kolide or testing a quick feature, dev mode is ideal.
-Keep in mind that, since everything is in-memory, when you kill the process,
-everything you did in dev mode will be lost. This is nice for development but
-not so nice for production environments.
-
-If you've used `make build` to build the Kolide binary, you can also run the
-following to launch an in-memory instance of the server:
-
-```
-make run
-```

--- a/cli/serve.go
+++ b/cli/serve.go
@@ -13,7 +13,6 @@ import (
 	kitlog "github.com/go-kit/kit/log"
 	kitprometheus "github.com/go-kit/kit/metrics/prometheus"
 	"github.com/kolide/kolide-ose/server/config"
-	"github.com/kolide/kolide-ose/server/datastore/inmem"
 	"github.com/kolide/kolide-ose/server/datastore/mysql"
 	"github.com/kolide/kolide-ose/server/kolide"
 	"github.com/kolide/kolide-ose/server/mail"
@@ -33,8 +32,6 @@ type initializer interface {
 }
 
 func createServeCmd(configManager config.Manager) *cobra.Command {
-	var devMode = false
-
 	serveCmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Launch the kolide server",
@@ -59,31 +56,11 @@ the way that the kolide server works.
 
 			var ds kolide.Datastore
 			var err error
-			var mailService kolide.MailService
+			mailService := mail.NewService()
 
-			if devMode {
-				fmt.Print(
-					"********************************************************************************\n",
-					"* Warning:                                                                     *\n",
-					"*                                                                              *\n",
-					"*    Developer mode is currently enabled, so Kolide is using a transient,      *\n",
-					"*    in-memory DB. Any changes you make to the database will not be saved      *\n",
-					"*    across process restarts. This should NOT be used in production.           *\n",
-					"*                                                                              *\n",
-					"********************************************************************************\n",
-				)
-
-				if ds, err = inmem.New(config); err != nil {
-					initFatal(err, "initializing inmem database")
-				}
-				mailService = mail.NewDevService()
-			} else {
-				const defaultMaxAttempts = 15
-				ds, err = mysql.New(config.Mysql, clock.C, mysql.Logger(logger))
-				if err != nil {
-					initFatal(err, "initializing datastore")
-				}
-				mailService = mail.NewService()
+			ds, err = mysql.New(config.Mysql, clock.C, mysql.Logger(logger))
+			if err != nil {
+				initFatal(err, "initializing datastore")
 			}
 
 			if initializingDS, ok := ds.(initializer); ok {
@@ -93,12 +70,8 @@ the way that the kolide server works.
 			}
 
 			var resultStore kolide.QueryResultStore
-			if devMode {
-				resultStore = pubsub.NewInmemQueryResults()
-			} else {
-				redisPool := pubsub.NewRedisPool(config.Redis.Address, config.Redis.Password)
-				resultStore = pubsub.NewRedisQueryResults(redisPool)
-			}
+			redisPool := pubsub.NewRedisPool(config.Redis.Address, config.Redis.Password)
+			resultStore = pubsub.NewRedisQueryResults(redisPool)
 
 			svc, err := service.NewService(ds, resultStore, logger, config, mailService, clock.C)
 			if err != nil {
@@ -163,7 +136,7 @@ the way that the kolide server works.
 
 			errs := make(chan error, 2)
 			go func() {
-				if !config.Server.TLS || (devMode && !configManager.IsSet("server.tls")) {
+				if !config.Server.TLS {
 					logger.Log("transport", "http", "address", config.Server.Address, "msg", "listening")
 					errs <- http.ListenAndServe(config.Server.Address, nil)
 				} else {
@@ -185,8 +158,6 @@ the way that the kolide server works.
 			logger.Log("terminated", <-errs)
 		},
 	}
-
-	serveCmd.PersistentFlags().BoolVar(&devMode, "dev", false, "Use dev settings (in-mem DB, etc.)")
 
 	return serveCmd
 }

--- a/server/mail/mail.go
+++ b/server/mail/mail.go
@@ -16,12 +16,7 @@ func NewService() kolide.MailService {
 	return &mailService{}
 }
 
-func NewDevService() kolide.MailService {
-	return &devMailService{}
-}
-
 type mailService struct{}
-type devMailService struct{}
 
 type sender interface {
 	sendMail(e kolide.Email, msg []byte) error
@@ -61,15 +56,6 @@ func getMessageBody(e kolide.Email) ([]byte, error) {
 	subject := "Subject: " + e.Subject + "\r\n"
 	msg := []byte(subject + mime + content + "\r\n" + string(body) + "\r\n")
 	return msg, nil
-}
-
-func (dm devMailService) SendEmail(e kolide.Email) error {
-	msg, err := getMessageBody(e)
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(msg))
-	return nil
 }
 
 func (m mailService) SendEmail(e kolide.Email) error {


### PR DESCRIPTION
There needs to be a lot of work done to switch tests from using inmem, but this PR removes the user facing `--dev` flag 

since we'll have real users first, I thought I'd remove this option sooner rather than later. 