### PR TITLE
Don't inject a duplicate script tag in react.tmpl

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ var plugins = [
   new webpack.optimize.DedupePlugin(),
   new HtmlWebpackPlugin({
     filename: '../frontend/templates/react.tmpl',
+    inject: false,
     template: 'frontend/templates/react.ejs'
   })
 ];


### PR DESCRIPTION
This PR makes a one line change to our webpack config which will prevent the `HtmlWebpackPlugin` from appending its own script tag to the bottom of the template.

Just some commentary here, this is the dumbest default behavior I've ever seen in my life.


This fixes the following errors introduces in #1022 which are caused by the JS running twice.

![image](https://cloud.githubusercontent.com/assets/315873/22115728/28006510-de3c-11e6-990d-f0cebe88274a.png)

