### PR TITLE
Returns an empty array when array items are removed

### DIFF
--- a/frontend/utilities/deep_difference/deep_difference.tests.js
+++ b/frontend/utilities/deep_difference/deep_difference.tests.js
@@ -46,4 +46,11 @@ describe('deepDifference - utility', () => {
     expect(deepDifference(obj1, obj2)).toEqual(obj1);
     expect(deepDifference(obj2, obj1)).toEqual(obj2);
   });
+
+  it('returns an empty array when comparing an empty array against a non-empty array', () => {
+    const obj1 = { pack_name: 'My Pack', label_ids: [] };
+    const obj2 = { pack_name: 'My Pack', label_ids: [1, 2] };
+
+    expect(deepDifference(obj1, obj2)).toEqual({ label_ids: [] });
+  });
 });

--- a/frontend/utilities/deep_difference/index.js
+++ b/frontend/utilities/deep_difference/index.js
@@ -9,10 +9,14 @@ const deepDifference = (obj1, obj2) => {
     if (isEqual(value, obj2Value)) return;
 
     if (isArray(value) && isArray(obj2Value)) {
-      const arrayDiff = differenceWith(value, obj2Value, isEqual);
+      if (!value.length && obj2Value.length) {
+        result[key] = value;
+      } else {
+        const arrayDiff = differenceWith(value, obj2Value, isEqual);
 
-      if (arrayDiff.length) {
-        result[key] = arrayDiff;
+        if (arrayDiff.length) {
+          result[key] = arrayDiff;
+        }
       }
     } else if (isObject(value) && isObject(obj2Value)) {
       result[key] = deepDifference(value, obj2Value);


### PR DESCRIPTION
I found when editing a pack and removing the "All Hosts" label that the request was being sent without the parameter `label_ids: []`. This fixes the request to send the correct parameters, but there is still a bug PATCHing the targets on a pack as the response I get from the API does not reflect the new pack targets.