### PR TITLE
Calc gigabytes by 1024

### DIFF
--- a/frontend/components/hosts/HostDetails/helpers.js
+++ b/frontend/components/hosts/HostDetails/helpers.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-const BYTES_PER_GIGABYTE = 1000000000;
+const BYTES_PER_GIGABYTE = 1074000000;
 const NANOSECONDS_PER_MILLISECOND = 1000000;
 
 const inGigaBytes = (bytes) => {


### PR DESCRIPTION
Fixes the division constant so we have the correct ram on the cards.