### PR TITLE
add hostname field to distributed query results row

### DIFF
--- a/server/service/service_campaigns.go
+++ b/server/service/service_campaigns.go
@@ -125,10 +125,10 @@ func (svc service) StreamCampaignResults(ctx context.Context, conn *websocket.Co
 	lastStatus := status.Status
 
 	// to improve performance of the frontend rendering the results table, we
-	// add the "hostname" field to every row.
+	// add the "host_hostname" field to every row.
 	mapHostnameRows := func(hostname string, rows []map[string]string) {
 		for _, row := range rows {
-			row["hostname"] = hostname
+			row["host_hostname"] = hostname
 		}
 	}
 


### PR DESCRIPTION
Closes #1079

@mikestone14 I would prefer if we renamed the field to something more unique than `hostname`, because some queries also return an actual `hostname` field, and we're overriding it. It _should_ be the same, but you never know. 