### PR TITLE
make mac enrollment package

### DIFF
--- a/docs/hosts/mac-enterprise.md
+++ b/docs/hosts/mac-enterprise.md
@@ -14,15 +14,14 @@ Next, you'll have to edit the `config.mk` file. You'll find all the necessary in
 
  - Set the `KOLIDE_HOSTNAME` variable to the FQDN of your kolide server.
  - Set the `ENROLL_SECRET` variable to the enroll secret you got from kolide.
- - Paste the contents of the kolide TLS certificate after the 
+ - Paste the contents of the kolide TLS certificate after the following line:
       ```
       define KOLIDE_TLS_CERTIFICATE
       ``` 
-      line.
 
 Note that osqueryd requires a full certificate chain, even for certificates which might be trusted by your keychain. The "Fetch Kolide Certificate" button in the Add New Host screen will attempt to fetch the full chain for you. 
 
 Once you've configured the `config.mk` file with the corect variables, you can run `make` in the `tools/mac` directory. Running `make` will create a new `kolide-enroll.pkg` file which you can import into your software repository and deploy to your macs. 
 
-The enrollment package must installed after the osqueryd package, and will require a restart -- it will install a LaunchDaemon to keep osqueryd running.  
+The enrollment package must installed after the osqueryd package, and will install a LaunchDaemon to keep the osqueryd process running.
 

--- a/tools/mac/Makefile
+++ b/tools/mac/Makefile
@@ -18,5 +18,8 @@ build: clean
 	mkdir -p root/etc/osquery
 	echo $(ENROLL_SECRET) > root/etc/osquery/kolide_secret
 	echo "$$KOLIDE_TLS_CERTIFICATE" > root/etc/osquery/kolide.crt
+	
+	# validate the certificate
+	openssl x509 -in root/etc/osquery/kolide.crt -text > /dev/null
 	echo "$$KOLIDE_FLAGS" > root/etc/osquery/kolide.flags
-	pkgbuild --info PackageInfo --root root --identifier ${PKGID} --version ${PKGVERSION} out/${PKGNAME}-${PKGVERSION}.pkg
+	pkgbuild --root root --scripts scripts --identifier ${PKGID} --version ${PKGVERSION} out/${PKGNAME}-${PKGVERSION}.pkg

--- a/tools/mac/PackageInfo
+++ b/tools/mac/PackageInfo
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<pkg-info postinstall-action="restart"/>

--- a/tools/mac/root/Library/LaunchDaemons/co.kolide.osquery.enroll.plist
+++ b/tools/mac/root/Library/LaunchDaemons/co.kolide.osquery.enroll.plist
@@ -12,9 +12,9 @@
     <key>RunAtLoad</key>
     <true/>
     <key>StandardErrorPath</key>
-	<string>/var/log/osquery-error.log</string>
+    <string>/var/log/osquery/osquery-error.log</string>
 	<key>StandardOutPath</key>
-	<string>/var/log/osquery-output.log</string>
+    <string>/var/log/osquery/osquery-output.log</string>
 </dict>
 </plist>
 

--- a/tools/mac/scripts/postinstall
+++ b/tools/mac/scripts/postinstall
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+[[ $3 != "/" ]] && exit 0
+
+/bin/launchctl load /Library/LaunchDaemons/co.kolide.osquery.enroll.plist
+
+exit 0


### PR DESCRIPTION
This PR adds a Makefile to create a macOS package to enroll osqueryd into kolide. 
running `make` in the mac directory will create `kolide-enroll-1.0.0.pkg` which can be installed along with the osquery.pkg to enroll kolide in an enterprise mac environment. 

The user will have to modify the included `config.mk` file with the variables from the Add Hosts panel.

When installed the package will add the flags, cert and enrollment secret to /etc/osquery/... and will also add a LaunchDaemon which starts kolide on boot and keeps it running. Because this is a LaunchDaemon, the end user machine will be required to restart. 