### PR TITLE
Poll for labels every 5 seconds

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.jsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.jsx
@@ -80,7 +80,10 @@ export class ManageHostsPage extends Component {
 
   componentDidMount () {
     const { dispatch } = this.props;
-    const getLabels = () => dispatch(labelActions.loadAll());
+    const getLabels = () => {
+      dispatch(labelActions.loadAll());
+      dispatch(getStatusLabelCounts);
+    };
 
     this.interval = global.window.setInterval(getLabels, 5000);
 


### PR DESCRIPTION
related to #976 

This PR polls for labels every 5 seconds on the Manage Hosts Page. The reason we need to poll is because after a new label is created there is a gap of time before the labels `host_ids` are populated. By polling we will get updated `host_ids` values for labels every 5 seconds.