### PR TITLE
Stop Query table headers from overflowing

### DIFF
--- a/frontend/components/queries/QueryResultsTable/_styles.scss
+++ b/frontend/components/queries/QueryResultsTable/_styles.scss
@@ -43,6 +43,14 @@
     th {
       padding: $pad-small $pad-xsmall;
       min-width: 125px;
+
+      span {
+        white-space: nowrap;
+
+        .kolidecon {
+          margin-right: 5px;
+        }
+      }
     }
 
     .input-field {
@@ -52,14 +60,9 @@
 
   tbody {
     background-color: $white;
-    // height: 550px;
-    // min-width: 100%;
-    // overflow: auto;
-    // display: inline-block;
 
     td {
       padding: $pad-xsmall;
-      // min-width: 125px;
     }
 
     tr {


### PR DESCRIPTION
Closes #1062 

![image](https://cloud.githubusercontent.com/assets/122591/22275947/eb8b877a-e275-11e6-884f-ac519e015f0d.png)

I didn't have a way to test an actual macOS device for that exact table name, but i think it should be fixed regardless.