### PR TITLE
Add inline flag documentation in --help

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -90,45 +90,70 @@ type KolideConfig struct {
 // filled into the KolideConfig struct
 func (man Manager) addConfigs() {
 	// MySQL
-	man.addConfigString("mysql.address", "localhost:3306", "MySQL server address (host:port)")
-	man.addConfigString("mysql.username", "kolide", "MySQL server username")
-	man.addConfigString("mysql.password", "kolide", "MySQL server password (prefer env variable for security)")
-	man.addConfigString("mysql.database", "kolide", "MySQL database name")
+	man.addConfigString("mysql.address", "localhost:3306",
+		"MySQL server address (host:port)")
+	man.addConfigString("mysql.username", "kolide",
+		"MySQL server username")
+	man.addConfigString("mysql.password", "kolide",
+		"MySQL server password (prefer env variable for security)")
+	man.addConfigString("mysql.database", "kolide",
+		"MySQL database name")
 
 	// Redis
-	man.addConfigString("redis.address", "localhost:6379", "Redis server address (host:port)")
-	man.addConfigString("redis.password", "", "Redis server password (prefer env variable for security)")
+	man.addConfigString("redis.address", "localhost:6379",
+		"Redis server address (host:port)")
+	man.addConfigString("redis.password", "",
+		"Redis server password (prefer env variable for security)")
 
 	// Server
-	man.addConfigString("server.address", "0.0.0.0:8080", "Kolide server address (host:port)")
-	man.addConfigString("server.cert", "./tools/osquery/kolide.crt", "Kolide TLS certificate path")
-	man.addConfigString("server.key", "./tools/osquery/kolide.key", "Kolide TLS key path")
-	man.addConfigBool("server.tls", true, "Enable TLS (required for osqueryd communication)")
+	man.addConfigString("server.address", "0.0.0.0:8080",
+		"Kolide server address (host:port)")
+	man.addConfigString("server.cert", "./tools/osquery/kolide.crt",
+		"Kolide TLS certificate path")
+	man.addConfigString("server.key", "./tools/osquery/kolide.key",
+		"Kolide TLS key path")
+	man.addConfigBool("server.tls", true,
+		"Enable TLS (required for osqueryd communication)")
 
 	// Auth
-	man.addConfigString("auth.jwt_key", "CHANGEME", "JWT session token key")
-	man.addConfigInt("auth.bcrypt_cost", 12, "Bcrypt iterations")
-	man.addConfigInt("auth.salt_key_size", 24, "Size of salt for passwords")
+	man.addConfigString(
+		"auth.jwt_key", "CHANGEME", "JWT session token key")
+	man.addConfigInt("auth.bcrypt_cost", 12,
+		"Bcrypt iterations")
+	man.addConfigInt("auth.salt_key_size", 24,
+		"Size of salt for passwords")
 
 	// App
-	man.addConfigString("app.token_key", "CHANGEME", "Secret key for generating invite and reset tokens")
-	man.addConfigDuration("app.invite_token_validity_period", 5*24*time.Hour, "Duration invite tokens remain valid (i.e. 1h)")
-	man.addConfigInt("app.token_key_size", 24, "Size of generated tokens")
+	man.addConfigString("app.token_key", "CHANGEME",
+		"Secret key for generating invite and reset tokens")
+	man.addConfigDuration("app.invite_token_validity_period", 5*24*time.Hour,
+		"Duration invite tokens remain valid (i.e. 1h)")
+	man.addConfigInt("app.token_key_size", 24,
+		"Size of generated tokens")
 
 	// Session
-	man.addConfigInt("session.key_size", 64, "Size of generated session keys")
-	man.addConfigDuration("session.duration", 24*90*time.Hour, "Duration session keys remain valid (i.e. 24h)")
+	man.addConfigInt("session.key_size", 64,
+		"Size of generated session keys")
+	man.addConfigDuration("session.duration", 24*90*time.Hour,
+		"Duration session keys remain valid (i.e. 24h)")
 
 	// Osquery
-	man.addConfigInt("osquery.node_key_size", 24, "Size of generated osqueryd node keys")
-	man.addConfigString("osquery.status_log_file", "/tmp/osquery_status", "Path for osqueryd status logs")
-	man.addConfigString("osquery.result_log_file", "/tmp/osquery_result", "Path for osqueryd result logs")
-	man.addConfigDuration("osquery.label_update_interval", 1*time.Hour, "Interval to update host label membership (i.e. 1h)")
+	man.addConfigInt("osquery.node_key_size", 24,
+		"Size of generated osqueryd node keys")
+	man.addConfigString("osquery.status_log_file", "/tmp/osquery_status",
+		"Path for osqueryd status logs")
+	man.addConfigString("osquery.result_log_file", "/tmp/osquery_result",
+		"Path for osqueryd result logs")
+	man.addConfigDuration("osquery.label_update_interval", 1*time.Hour,
+		"Interval to update host label membership (i.e. 1h)")
 
 	// Logging
-	man.addConfigBool("logging.debug", false, "Enable debug logging")
-	man.addConfigBool("logging.json", false, "Log in JSON format")
-	man.addConfigBool("logging.disable_banner", false, "Disable startup banner")
+	man.addConfigBool("logging.debug", false,
+		"Enable debug logging")
+	man.addConfigBool("logging.json", false,
+		"Log in JSON format")
+	man.addConfigBool("logging.disable_banner", false,
+		"Disable startup banner")
 }
 
 // LoadConfig will load the config variables into a fully initialized


### PR DESCRIPTION
- Cleanup unused app.web_address flag

New help text:
```
osquery management and orchestration

Configurable Options:

Options may be supplied in a yaml configuration file or via environment
variables. You only need to define the configuration values for which you
wish to override the default value.

Usage:
  kolide [command]

Available Commands:
  config_dump Dump the parsed configuration in yaml format
  prepare     Subcommands for initializing kolide infrastructure
  serve       Launch the kolide server
  version     Print kolide version

Flags:
      --app_invite_token_validity_period duration   Env: KOLIDE_APP_INVITE_TOKEN_VALIDITY_PERIOD
		Duration invite tokens remain valid (i.e. 1h) (default 120h0m0s)
      --app_token_key string                        Env: KOLIDE_APP_TOKEN_KEY
		Secret key for generating invite and reset tokens (default "CHANGEME")
      --app_token_key_size int                      Env: KOLIDE_APP_TOKEN_KEY_SIZE
		Size of generated tokens (default 24)
      --auth_bcrypt_cost int                        Env: KOLIDE_AUTH_BCRYPT_COST
		Bcrypt iterations (default 12)
      --auth_jwt_key string                         Env: KOLIDE_AUTH_JWT_KEY
		JWT session token key (default "CHANGEME")
      --auth_salt_key_size int                      Env: KOLIDE_AUTH_SALT_KEY_SIZE
		Size of salt for passwords (default 24)
  -c, --config string                               Path to a configuration file
      --logging_debug                               Env: KOLIDE_LOGGING_DEBUG
		Enable debug logging
      --logging_disable_banner                      Env: KOLIDE_LOGGING_DISABLE_BANNER
		Disable startup banner
      --logging_json                                Env: KOLIDE_LOGGING_JSON
		Log in JSON format
      --mysql_address string                        Env: KOLIDE_MYSQL_ADDRESS
		MySQL server address (host:port) (default "localhost:3306")
      --mysql_database string                       Env: KOLIDE_MYSQL_DATABASE
		MySQL database name (default "kolide")
      --mysql_password string                       Env: KOLIDE_MYSQL_PASSWORD
		MySQL server password (prefer env variable for security) (default "kolide")
      --mysql_username string                       Env: KOLIDE_MYSQL_USERNAME
		MySQL server username (default "kolide")
      --osquery_label_update_interval duration      Env: KOLIDE_OSQUERY_LABEL_UPDATE_INTERVAL
		Interval to update host label membership (i.e. 1h) (default 1h0m0s)
      --osquery_node_key_size int                   Env: KOLIDE_OSQUERY_NODE_KEY_SIZE
		Size of generated osqueryd node keys (default 24)
      --osquery_result_log_file string              Env: KOLIDE_OSQUERY_RESULT_LOG_FILE
		Path for osqueryd result logs (default "/tmp/osquery_result")
      --osquery_status_log_file string              Env: KOLIDE_OSQUERY_STATUS_LOG_FILE
		Path for osqueryd status logs (default "/tmp/osquery_status")
      --redis_address string                        Env: KOLIDE_REDIS_ADDRESS
		Redis server address (host:port) (default "localhost:6379")
      --redis_password string                       Env: KOLIDE_REDIS_PASSWORD
		Redis server password (prefer env variable for security)
      --server_address string                       Env: KOLIDE_SERVER_ADDRESS
		Kolide server address (host:port) (default "0.0.0.0:8080")
      --server_cert string                          Env: KOLIDE_SERVER_CERT
		Kolide TLS certificate path (default "./tools/osquery/kolide.crt")
      --server_key string                           Env: KOLIDE_SERVER_KEY
		Kolide TLS key path (default "./tools/osquery/kolide.key")
      --server_tls                                  Env: KOLIDE_SERVER_TLS
		Enable TLS (required for osqueryd communication) (default true)
      --session_duration duration                   Env: KOLIDE_SESSION_DURATION
		Duration session keys remain valid (i.e. 24h) (default 2160h0m0s)
      --session_key_size int                        Env: KOLIDE_SESSION_KEY_SIZE
		Size of generated session keys (default 64)

Use "kolide [command] --help" for more information about a command.
```

Old help text:
```
osquery management and orchestration

Configurable Options:

Options may be supplied in a yaml configuration file or via environment
variables. You only need to define the configuration values for which you
wish to override the default value.

Usage:
  kolide [command]

Available Commands:
  config_dump Dump the parsed configuration in yaml format
  prepare     Subcommands for initializing kolide infrastructure
  serve       Launch the kolide server
  version     Print kolide version

Flags:
      --app_invite_token_validity_period duration   Env: KOLIDE_APP_INVITE_TOKEN_VALIDITY_PERIOD (default 120h0m0s)
      --app_token_key string                        Env: KOLIDE_APP_TOKEN_KEY (default "CHANGEME")
      --app_token_key_size int                      Env: KOLIDE_APP_TOKEN_KEY_SIZE (default 24)
      --app_web_address string                      Env: KOLIDE_APP_WEB_ADDRESS (default "0.0.0.0:8080")
      --auth_bcrypt_cost int                        Env: KOLIDE_AUTH_BCRYPT_COST (default 12)
      --auth_jwt_key string                         Env: KOLIDE_AUTH_JWT_KEY (default "CHANGEME")
      --auth_salt_key_size int                      Env: KOLIDE_AUTH_SALT_KEY_SIZE (default 24)
  -c, --config string                               Path to a configuration file
      --logging_debug                               Env: KOLIDE_LOGGING_DEBUG
      --logging_disable_banner                      Env: KOLIDE_LOGGING_DISABLE_BANNER
      --logging_json                                Env: KOLIDE_LOGGING_JSON
      --mysql_address string                        Env: KOLIDE_MYSQL_ADDRESS (default "localhost:3306")
      --mysql_database string                       Env: KOLIDE_MYSQL_DATABASE (default "kolide")
      --mysql_password string                       Env: KOLIDE_MYSQL_PASSWORD (default "kolide")
      --mysql_username string                       Env: KOLIDE_MYSQL_USERNAME (default "kolide")
      --osquery_label_update_interval duration      Env: KOLIDE_OSQUERY_LABEL_UPDATE_INTERVAL (default 1h0m0s)
      --osquery_node_key_size int                   Env: KOLIDE_OSQUERY_NODE_KEY_SIZE (default 24)
      --osquery_result_log_file string              Env: KOLIDE_OSQUERY_RESULT_LOG_FILE (default "/tmp/osquery_result")
      --osquery_status_log_file string              Env: KOLIDE_OSQUERY_STATUS_LOG_FILE (default "/tmp/osquery_status")
      --redis_address string                        Env: KOLIDE_REDIS_ADDRESS (default "localhost:6379")
      --redis_password string                       Env: KOLIDE_REDIS_PASSWORD
      --server_address string                       Env: KOLIDE_SERVER_ADDRESS (default "0.0.0.0:8080")
      --server_cert string                          Env: KOLIDE_SERVER_CERT (default "./tools/osquery/kolide.crt")
      --server_key string                           Env: KOLIDE_SERVER_KEY (default "./tools/osquery/kolide.key")
      --server_tls                                  Env: KOLIDE_SERVER_TLS (default true)
      --session_duration duration                   Env: KOLIDE_SESSION_DURATION (default 2160h0m0s)
      --session_key_size int                        Env: KOLIDE_SESSION_KEY_SIZE (default 64)

Use "kolide [command] --help" for more information about a command.
```