### PR TITLE
Fixing broken documentation links

### DIFF
--- a/frontend/components/hosts/AddHostModal/AddHostModal.jsx
+++ b/frontend/components/hosts/AddHostModal/AddHostModal.jsx
@@ -64,7 +64,7 @@ class AddHostModal extends Component {
         <div className={`${baseClass}__manual-install-content`}>
           <ol className={`${baseClass}__install-steps`}>
             <li>
-              <h4><a href="https://docs.kolide.co/using-kolide/master/hosts/adding-hosts.html" target="_blank" rel="noopener noreferrer">Kolide / Osquery - Install Docs <Icon name="external-link" /></a></h4>
+              <h4><a href="https://docs.kolide.co/kolide/current/infrastructure/adding-hosts-to-kolide.html" target="_blank" rel="noopener noreferrer">Kolide / Osquery - Install Docs <Icon name="external-link" /></a></h4>
               <p>In order to install <strong>osquery</strong> on a client you will need the items below:</p>
             </li>
             <li>

--- a/frontend/components/side_panels/SiteNavSidePanel/navItems.js
+++ b/frontend/components/side_panels/SiteNavSidePanel/navItems.js
@@ -104,7 +104,7 @@ export default (admin) => {
       name: 'Help',
       location: {
         regex: /^\/help/,
-        pathname: 'https://docs.kolide.co/using-kolide/master',
+        pathname: 'https://docs.kolide.co/kolide/current/',
       },
       subItems: [],
     },


### PR DESCRIPTION
With the new URL pattern that we schemed up for the docs site, these
links need to updated in the application.