### PR TITLE
Use localhost if MySQL environment variable is not set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ ifdef CIRCLE_TAG
 	DOCKER_IMAGE_TAG = ${CIRCLE_TAG}
 endif
 
+ifndef MYSQL_PORT_3306_TCP_ADDR
+	MYSQL_PORT_3306_TCP_ADDR = 127.0.0.1
+endif
+
 all: build
 
 define HELP_TEXT


### PR DESCRIPTION
I think that this will make it easier to use the demo dump utilities
with minimal configuration.