### PR TITLE
Locks jsdom at version 9.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "import-glob-loader": "^1.1.0",
     "isomorphic-fetch": "^2.2.1",
     "js-md5": "^0.4.1",
-    "jsdom": "^9.5.0",
+    "jsdom": "9.9.1",
     "json-loader": "^0.5.4",
     "lodash": "^4.3.0",
     "moment": "^2.15.1",


### PR DESCRIPTION
closes #1186 

When removing and re-installing node dependencies, jsdom version 9.10.0 is installed which does not set DOM Element behavior such as scrollLeft and scrollTop. This in turn caused an error with the react-select input in tests as it uses the scrollTop attribute. This PR rolls back the jsdom version to 9.9.1.

More info here: https://github.com/tmpvar/jsdom/issues/1728