### PR TITLE
return a licensing error(instead of 500) with bad JWT

### DIFF
--- a/server/service/service_licenses.go
+++ b/server/service/service_licenses.go
@@ -16,7 +16,7 @@ func (svc service) License(ctx context.Context) (*kolide.License, error) {
 func (svc service) SaveLicense(ctx context.Context, jwtToken string) (*kolide.License, error) {
 	publicKey, err := svc.ds.LicensePublicKey(jwtToken)
 	if err != nil {
-		return nil, err
+		return nil, licensingError{err.Error()}
 	}
 	updated, err := svc.ds.SaveLicense(jwtToken, publicKey)
 	if err != nil {


### PR DESCRIPTION
returns a 402 instead of 500