### PR TITLE
add namedError in addition to baseError

### DIFF
--- a/server/kolide/licenses.go
+++ b/server/kolide/licenses.go
@@ -26,8 +26,9 @@ type LicenseStore interface {
 }
 
 type LicenseService interface {
-	// LicenseClaims returns details of a customer license that determine authorization
-	// to use the Kolide product.
+	// License returns details of a customer license that determine authorization
+	// to use the Kolide product. If the customer has not uploaded a token,
+	// the license Token will be nil.
 	License(ctx context.Context) (*License, error)
 
 	// SaveLicense writes jwt token string to database after performing

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -422,7 +422,7 @@ func WithSetup(svc kolide.Service, logger kitlog.Logger, next http.Handler) http
 		))
 		configRouter.Handle("/api/v1/license", kithttp.NewServer(
 			context.Background(),
-			makePostLicenseEndpoint(svc),
+			makeSetupLicenseEndpoint(svc),
 			decodeLicenseRequest,
 			encodeResponse,
 		))

--- a/server/service/transport_error.go
+++ b/server/service/transport_error.go
@@ -28,6 +28,14 @@ func baseError(err string) []map[string]string {
 	}
 }
 
+// same as baseError, but replaces "base" with different name.
+func namedError(name string, err string) []map[string]string {
+	return []map[string]string{map[string]string{
+		"name":   name,
+		"reason": err},
+	}
+}
+
 // encode error and status header to the client
 func encodeError(ctx context.Context, err error, w http.ResponseWriter) {
 	// Unwrap Go-Kit Error
@@ -46,7 +54,7 @@ func encodeError(ctx context.Context, err error, w http.ResponseWriter) {
 	if e, ok := err.(licensingError); ok {
 		le := jsonError{
 			Message: "Licensing Error",
-			Errors:  baseError(e.LicensingError()),
+			Errors:  namedError(e.LicensingError(), "license"),
 		}
 		w.WriteHeader(http.StatusPaymentRequired)
 		enc.Encode(le)


### PR DESCRIPTION
Clean up error handling so a license error is returned to the frontend(instead of base/500) for most cases where the uploaded license is not valid. 

Also removed the restriction that the license can only be uploaded once. Just like with the other initial setup screens, the endpoint router is removed after initial setup. 