### PR TITLE
Enable basic autocompletion

### DIFF
--- a/frontend/components/KolideAce/KolideAce.jsx
+++ b/frontend/components/KolideAce/KolideAce.jsx
@@ -3,6 +3,7 @@ import AceEditor from 'react-ace';
 import classnames from 'classnames';
 import 'brace/mode/sql';
 import 'brace/ext/linking';
+import 'brace/ext/language_tools';
 
 import './mode';
 import './theme';


### PR DESCRIPTION
closes #1046 

We already had most of this functionality in place, we just need to import the language tools extension.