### PR TITLE
Removes resolve link from SMTP Warning on App Settings Page

### DIFF
--- a/frontend/components/SmtpWarning/SmtpWarning.jsx
+++ b/frontend/components/SmtpWarning/SmtpWarning.jsx
@@ -21,7 +21,7 @@ const SmtpWarning = ({ className, onDismiss, onResolve, shouldShowWarning }) => 
       </div>
       <span className={`${baseClass}__text`}>Email is not currently configured in Kolide. Many features rely on email to work.</span>
       {onDismiss && <Button onClick={onDismiss} variant="unstyled">Dismiss</Button>}
-      <Button onClick={onResolve} variant="unstyled">Resolve</Button>
+      {onResolve && <Button onClick={onResolve} variant="unstyled">Resolve</Button>}
     </div>
   );
 };


### PR DESCRIPTION
closes #814 

This PR removes the "RESOLVE" link in the SMTP Warning on the App Settings Page. Since the button currently does nothing I figure this is a decent starting point and we can add it back in when we decide what the RESOLVE link should do when clicked.