### PR TITLE
Only render query results when there are result totals

### DIFF
--- a/frontend/pages/queries/QueryPage/QueryPage.jsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.jsx
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import FileSaver from 'file-saver';
-import { filter, includes, isArray, isEqual } from 'lodash';
+import { filter, get, includes, isArray, isEqual } from 'lodash';
 import moment from 'moment';
 import { push } from 'react-router-redux';
 
@@ -311,14 +311,16 @@ export class QueryPage extends Component {
     const { campaign, queryIsRunning } = this.state;
     const { onExportQueryResults } = this;
     const loading = queryIsRunning && !campaign.hosts_count.total;
+    const totalHostsCount = get(campaign, ['totals', 'count'], 0);
+
+    if (!loading && !totalHostsCount) {
+      return false;
+    }
+
     const resultsClasses = classnames(`${baseClass}__results`, 'body-wrap', {
       [`${baseClass}__results--loading`]: loading,
     });
     let resultBody = '';
-
-    if (!loading && isEqual(campaign, DEFAULT_CAMPAIGN)) {
-      return false;
-    }
 
     if (loading) {
       resultBody = <Spinner />;

--- a/frontend/pages/queries/QueryPage/QueryPage.tests.jsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.tests.jsx
@@ -99,6 +99,36 @@ describe('QueryPage - component', () => {
 
       expect(page.find('QuerySidePanel').length).toEqual(1);
     });
+
+    describe('results table', () => {
+      const props = { dispatch: noop, query: queryStub, selectedOsqueryTable: defaultSelectedOsqueryTable };
+      const queryResult = { org_name: 'Kolide', org_url: 'https://kolide.co' };
+      const campaign = {
+        id: 1,
+        hosts_count: { failed: 0, successful: 1, total: 1 },
+        query_results: [queryResult],
+        totals: { count: 1 },
+      };
+
+      it('renders the results table when there are result totals', () => {
+        const Page = mount(<QueryPage {...props} />);
+
+        Page.setState({ campaign });
+
+        expect(Page.find('.query-page__results').length)
+          .toEqual(1, 'Expected the results section to render');
+      });
+
+      it('does not render the results table when there are no result totals', () => {
+        const Page = mount(<QueryPage {...props} />);
+        const campaignWithoutResults = { id: 1, hosts_count: { failed: 0, successful: 0, total: 0 } };
+
+        Page.setState({ campaign: campaignWithoutResults });
+
+        expect(Page.find('.query-page__results').length)
+          .toEqual(0, 'Expected the results section not to render');
+      });
+    });
   });
 
   it('sets selectedTargets based on host_ids', () => {
@@ -201,6 +231,9 @@ describe('QueryPage - component', () => {
           total: 1,
         },
         query_results: [queryResult],
+        totals: {
+          count: 1,
+        },
       };
       const queryResultsCSV = convertToCSV([queryResult]);
       const fileSaveSpy = spyOn(FileSave, 'saveAs');


### PR DESCRIPTION
This PR prevents the query results section from rendering when there are no hosts returned in the query. This was only happening when running a query against a target with 0 hosts. Previously a white section was rendering as shown in the screenshot below.

<img width="666" alt="screen shot 2017-02-17 at 10 14 59 am" src="https://cloud.githubusercontent.com/assets/2905145/23072985/d42e79a4-f501-11e6-82d0-ff024eff84ad.png">
