### PR TITLE
Link query name to the query page

### DIFF
--- a/frontend/components/side_panels/PackDetailsSidePanel/ScheduledQueriesSection.jsx
+++ b/frontend/components/side_panels/PackDetailsSidePanel/ScheduledQueriesSection.jsx
@@ -62,7 +62,7 @@ class ScheduledQueriesSection extends Component {
             return (
               <li key={`scheduled-query-${scheduledQuery.id}`}>
                 <Icon className={`${baseClass}__query-icon`} name="query" />
-                <Link to={`/queries/${scheduledQuery.id}`} className={`${baseClass}__query-name`}>{scheduledQuery.name}</Link>
+                <Link to={`/queries/${scheduledQuery.query_id}`} className={`${baseClass}__query-name`}>{scheduledQuery.name}</Link>
               </li>
             );
           })}

--- a/frontend/components/side_panels/PackDetailsSidePanel/ScheduledQueriesSection.tests.jsx
+++ b/frontend/components/side_panels/PackDetailsSidePanel/ScheduledQueriesSection.tests.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import expect from 'expect';
+import { mount } from 'enzyme';
+
+import ScheduledQueriesSection from 'components/side_panels/PackDetailsSidePanel/ScheduledQueriesSection';
+import { scheduledQueryStub } from 'test/stubs';
+
+describe('ScheduledQueriesSection - component', () => {
+  it('links the query name to the show query route', () => {
+    const scheduledQuery = { ...scheduledQueryStub, query_id: 55 };
+    const Component = mount(<ScheduledQueriesSection scheduledQueries={[scheduledQuery]} />);
+    const Link = Component.find('Link');
+
+    expect(Link.prop('to')).toEqual(`/queries/${scheduledQuery.query_id}`);
+  });
+});


### PR DESCRIPTION
@groob noticed that the queries in the pack detail side panel (screenshot below) were linking to the wrong query. It turns out we were linking to the queries page but using the scheduled query id instead of the scheduled query's query_id. This PR fixes this bug.

<img width="327" alt="screen shot 2017-02-17 at 11 36 40 am" src="https://cloud.githubusercontent.com/assets/2905145/23073995/605ad352-f505-11e6-89b7-0b802ceae6ce.png">
