### PR TITLE
Retrieve correct platform in detail queries

### DIFF
--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -195,7 +195,6 @@ var detailQueries = map[string]struct {
 				return nil
 			}
 
-			host.Platform = rows[0]["build_platform"]
 			host.OsqueryVersion = rows[0]["version"]
 
 			return nil
@@ -258,6 +257,7 @@ var detailQueries = map[string]struct {
 				host.Build = build
 			}
 
+			host.Platform = rows[0]["platform"]
 			host.PlatformLike = rows[0]["platform_like"]
 			host.CodeName = rows[0]["code_name"]
 			return nil

--- a/server/service/service_osquery_test.go
+++ b/server/service/service_osquery_test.go
@@ -477,6 +477,7 @@ func TestDetailQueries(t *testing.T) {
 ],
 "kolide_detail_query_os_version": [
     {
+        "platform": "darwin",
         "build": "15G1004",
         "major": "10",
         "minor": "10",


### PR DESCRIPTION
Previously we were using `build_platform`, which does not always properly
reflect the platform of the host running osquery. Now we should properly
retrieve the platform.

Fixes #1264