### PR TITLE
Re-add default decorators to osquery config

### DIFF
--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -81,11 +81,9 @@ func (svc service) GetClientConfig(ctx context.Context) (*kolide.OsqueryConfig, 
 	config := &kolide.OsqueryConfig{
 		Options: options,
 		Decorators: kolide.Decorators{
-			Interval: map[string][]string{
-				"3600": []string{
-					"SELECT uuid AS host_uuid FROM system_info;",
-					"SELECT hostname FROM system_info;",
-				},
+			Load: []string{
+				"SELECT uuid AS host_uuid FROM system_info;",
+				"SELECT hostname AS hostname FROM system_info;",
 			},
 		},
 		Packs: kolide.Packs{},


### PR DESCRIPTION
These decorators were removed in #953 due to an osquery bug. That bug is now
fixed, and we are adding the decorators back. We also now use `load` decorators
rather than `interval` decorators because they seem to function more reliably.