### PR TITLE
Fix inconsistencies with sidebar label counts

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/helpers.js
+++ b/frontend/pages/hosts/ManageHostsPage/helpers.js
@@ -6,19 +6,18 @@ const filterHosts = (hosts, label) => {
     return hosts;
   }
 
-  if (label.id === 'new') {
-    return filter(hosts, h => moment().diff(h.created_at, 'hours') <= 24);
+  if (label.type === 'status' && label.id === 'new') {
+    return filter(hosts, h => moment().diff(moment(h.created_at)) <= moment.duration(24, 'hours'));
   }
 
-  const { host_ids: hostIDs, platform, slug, type } = label;
+  const { host_ids: hostIDs, slug, type } = label;
 
   switch (type) {
     case 'all':
       return hosts;
     case 'status':
       return filter(hosts, { status: slug });
-    case 'platform':
-      return filter(hosts, { platform });
+    case 'platform': // Platform labels are implemented the same as custom labels
     case 'custom':
       return filter(hosts, h => includes(hostIDs, h.id));
     default:

--- a/frontend/pages/hosts/ManageHostsPage/helpers.tests.js
+++ b/frontend/pages/hosts/ManageHostsPage/helpers.tests.js
@@ -1,4 +1,5 @@
 import expect from 'expect';
+import moment from 'moment';
 
 import helpers from 'pages/hosts/ManageHostsPage/helpers';
 import { hostStub, labelStub } from 'test/stubs';
@@ -6,7 +7,23 @@ import { hostStub, labelStub } from 'test/stubs';
 const macHost = { ...hostStub, id: 1, platform: 'darwin', status: 'mia' };
 const ubuntuHost = { ...hostStub, id: 2, platform: 'ubuntu', status: 'offline' };
 const windowsHost = { ...hostStub, id: 3, platform: 'windows', status: 'online' };
-const allHosts = [macHost, ubuntuHost, windowsHost];
+// A (fixed) bug would have caused this host to be classified as new because
+// the time difference was rounded down to 24 hours
+const notNewHost = {
+  ...hostStub,
+  id: 4,
+  platform: 'centos',
+  status: 'online',
+  created_at: moment().subtract(24, 'hours').subtract(40, 'minutes').toISOString(),
+};
+const newHost = {
+  ...hostStub,
+  id: 5,
+  platform: 'centos',
+  status: 'online',
+  created_at: moment().subtract(10, 'hours'),
+};
+const allHosts = [macHost, ubuntuHost, windowsHost, notNewHost, newHost];
 
 describe('ManageHostsPage - helpers', () => {
   describe('#filterHosts', () => {
@@ -16,8 +33,14 @@ describe('ManageHostsPage - helpers', () => {
       expect(helpers.filterHosts(allHosts, allHostsLabel)).toEqual(allHosts);
     });
 
+    it('filters the new hosts', () => {
+      const newHostsLabel = { ...labelStub, type: 'status', id: 'new' };
+
+      expect(helpers.filterHosts(allHosts, newHostsLabel)).toEqual([newHost]);
+    });
+
     it('filters the platform label', () => {
-      const platformLabel = { ...labelStub, type: 'platform', platform: 'ubuntu' };
+      const platformLabel = { ...labelStub, type: 'platform', host_ids: [2] };
 
       expect(helpers.filterHosts(allHosts, platformLabel)).toEqual([ubuntuHost]);
     });
@@ -25,7 +48,7 @@ describe('ManageHostsPage - helpers', () => {
     it('filters the status label', () => {
       const statusLabel = { ...labelStub, type: 'status', slug: 'online' };
 
-      expect(helpers.filterHosts(allHosts, statusLabel)).toEqual([windowsHost]);
+      expect(helpers.filterHosts(allHosts, statusLabel)).toEqual([windowsHost, notNewHost, newHost]);
     });
 
     it('filters the custom label', () => {


### PR DESCRIPTION
- Fix a bug that caused hosts between 24 and 25 hours old to appear new
- Ensure "platform" labels use the count provided by the server

Fixes #1270