### PR TITLE
provide context for ServeFrontend 500 errors

### DIFF
--- a/cli/serve.go
+++ b/cli/serve.go
@@ -123,7 +123,7 @@ the way that the kolide server works.
 
 			var apiHandler, frontendHandler http.Handler
 			{
-				frontendHandler = prometheus.InstrumentHandler("get_frontend", service.ServeFrontend())
+				frontendHandler = prometheus.InstrumentHandler("get_frontend", service.ServeFrontend(httpLogger))
 				apiHandler = service.MakeHandler(ctx, svc, config.Auth.JwtKey, httpLogger)
 
 				setupRequired, err := service.RequireSetup(svc)


### PR DESCRIPTION
Closes #1343 

This PR adds logging and annotates errors coming from ServeFrontend so that `file does not exist` is not a total mystery to debug. 