### PR TITLE
do not return JSON response in healthz

### DIFF
--- a/cli/healthz_test.go
+++ b/cli/healthz_test.go
@@ -6,15 +6,17 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestHealthz(t *testing.T) {
-	failing := healthz(map[string]interface{}{
+	logger := log.NewNopLogger()
+	failing := healthz(logger, map[string]interface{}{
 		"mock": healthcheckFunc(func() error {
 			return errors.New("health check failed")
 		})})
-	ok := healthz(map[string]interface{}{
+	ok := healthz(logger, map[string]interface{}{
 		"mock": healthcheckFunc(func() error {
 			return nil
 		})})


### PR DESCRIPTION
healthz should only return 200 or 500 response.
returning error messages in the HTTP response can leak sensitive connection information
The exact error is logged by the server instead.

