### PR TITLE
Set payload from argument ID in entity delete action

### DIFF
--- a/frontend/redux/nodes/entities/base/base_config.js
+++ b/frontend/redux/nodes/entities/base/base_config.js
@@ -172,7 +172,7 @@ class BaseConfig {
 
         return apiCall(...args)
           .then((response) => {
-            const thunk = this._genericSuccess(type);
+            const thunk = this._genericSuccess(type, args);
 
             dispatch(this.successAction(response, thunk));
 
@@ -216,13 +216,23 @@ class BaseConfig {
     }
   }
 
-  _genericSuccess (type) {
+  _genericSuccess (type, args = {}) {
     const { actionTypes } = this;
 
     return (data) => {
+      const { TYPES } = BaseConfig;
+      let payload = { data };
+
+      switch  (type) {
+      case TYPES.DESTROY:
+        // In the case of a delete, the API does not return any object and we
+        // need to pull the ID from the request.
+        payload = { data: args[0].id };
+      }
+
       return {
         type: BaseConfig.successActionTypeFor(actionTypes, type),
-        payload: { data },
+        payload,
       };
     };
   }


### PR DESCRIPTION
This fixes a bug in which the frontend expected the entity ID to be returned in
the response body of a deletion request. Because the API does not do this (and
we don't want to make it do this), the ID needs to be made available for
updating the UI after the request returns.

Fixes #1398