### PR TITLE
Add Ubuntu16.04 host to docker-compose

### DIFF
--- a/tools/osquery/docker-compose.yml
+++ b/tools/osquery/docker-compose.yml
@@ -17,6 +17,21 @@ services:
         hard:  1000000000
         soft:  1000000000
 
+  ubuntu16-osquery:
+    image: "kolide/ubuntu16-osquery:${KOLIDE_OSQUERY_VERSION}"
+    volumes:
+      - ./kolide.crt:/etc/osquery/kolide.crt
+      - ./example_osquery.flags:/etc/osquery/osquery.flags
+    extra_hosts:
+      - "dockerhost:${LOCALHOST}"
+    environment:
+      ENROLL_SECRET: "${ENROLL_SECRET}"
+    command: osqueryd --flagfile=/etc/osquery/osquery.flags
+    ulimits:
+      core:
+        hard:  1000000000
+        soft:  1000000000
+
   centos7-osquery:
     image: "kolide/centos7-osquery:${KOLIDE_OSQUERY_VERSION}"
     volumes:


### PR DESCRIPTION
Enables testing Kolide with a Ubuntu16 host running osquery