### PR TITLE
Fix flapping online status with distributed_interval > logger_tls_period

### DIFF
--- a/server/service/service_options.go
+++ b/server/service/service_options.go
@@ -31,8 +31,14 @@ func (svc service) ExpectedCheckinInterval(ctx context.Context) (time.Duration, 
 	found := false
 
 	osqueryIntervalOptionNames := []string{
+		// Note that logger_tls_period cannot be used because the
+		// osqueryd client will not check in if there are no new logs
+		// to report. This makes it an unreliable indicator.
+		// config_tls_refresh could be used, however it can only be set
+		// as a flag and not a config option. Perhaps at some point we
+		// would extract that value and be able to use it for this
+		// calculation.
 		"distributed_interval",
-		"logger_tls_period",
 	}
 
 	for _, option := range osqueryIntervalOptionNames {

--- a/server/service/service_options_test.go
+++ b/server/service/service_options_test.go
@@ -58,15 +58,6 @@ func TestExpectedCheckinInterval(t *testing.T) {
 				Type:     kolide.OptionTypeInt,
 				ReadOnly: false,
 			},
-			kolide.Option{
-				ID:   loggerTlsPeriodID,
-				Name: "logger_tls_period",
-				Value: kolide.OptionValue{
-					Val: 100,
-				},
-				Type:     kolide.OptionTypeInt,
-				ReadOnly: false,
-			},
 		},
 	},
 	)
@@ -76,42 +67,17 @@ func TestExpectedCheckinInterval(t *testing.T) {
 	require.Nil(t, err)
 	updateLocalOptionValues(options)
 	require.Equal(t, 50, int(distributedInterval))
-	require.Equal(t, 100, int(loggerTlsPeriod))
+	require.Equal(t, 10, int(loggerTlsPeriod))
 	interval, err = svc.ExpectedCheckinInterval(ctx)
 	require.Nil(t, err)
 	assert.Equal(t, 50*time.Second*expectedCheckinIntervalMultiplier, interval)
-
-	options, err = svc.ModifyOptions(ctx, kolide.OptionRequest{
-		Options: []kolide.Option{
-			kolide.Option{
-				ID:   loggerTlsPeriodID,
-				Name: "logger_tls_period",
-				Value: kolide.OptionValue{
-					Val: 20,
-				},
-				Type:     kolide.OptionTypeInt,
-				ReadOnly: false,
-			},
-		},
-	},
-	)
-	require.Nil(t, err)
-
-	options, err = svc.GetOptions(ctx)
-	require.Nil(t, err)
-	updateLocalOptionValues(options)
-	require.Equal(t, 50, int(distributedInterval))
-	require.Equal(t, 20, int(loggerTlsPeriod))
-	interval, err = svc.ExpectedCheckinInterval(ctx)
-	require.Nil(t, err)
-	assert.Equal(t, 20*time.Second*expectedCheckinIntervalMultiplier, interval)
 
 	// Set the interval low enough to hit the minimum threshold
 	options, err = svc.ModifyOptions(ctx, kolide.OptionRequest{
 		Options: []kolide.Option{
 			kolide.Option{
-				ID:   loggerTlsPeriodID,
-				Name: "logger_tls_period",
+				ID:   distributedIntervalID,
+				Name: "distributed_interval",
 				Value: kolide.OptionValue{
 					Val: 2,
 				},
@@ -126,8 +92,8 @@ func TestExpectedCheckinInterval(t *testing.T) {
 	options, err = svc.GetOptions(ctx)
 	require.Nil(t, err)
 	updateLocalOptionValues(options)
-	require.Equal(t, 50, int(distributedInterval))
-	require.Equal(t, 2, int(loggerTlsPeriod))
+	require.Equal(t, 2, int(distributedInterval))
+	require.Equal(t, 10, int(loggerTlsPeriod))
 	interval, err = svc.ExpectedCheckinInterval(ctx)
 	require.Nil(t, err)
 	assert.Equal(t, minimumExpectedCheckinInterval, interval)


### PR DESCRIPTION
Closes #1419. See discussion there for more.