### PR TITLE
Fix issue where config interval can be number or string

### DIFF
--- a/server/kolide/import_config_unmarshaler.go
+++ b/server/kolide/import_config_unmarshaler.go
@@ -58,15 +58,14 @@ func boolptr(v interface{}) (*bool, error) {
 }
 
 // We expect a float64 here because of the way JSON represents numbers
-func uintptr(v interface{}) (*uint, error) {
+func uintptr(v interface{}) (*OsQueryConfigInt, error) {
 	if v == nil {
 		return nil, nil
 	}
-	f, ok := v.(float64)
-	if !ok {
-		return nil, wrongTypeError
+	i, err := unmarshalInteger(v)
+	if err != nil {
+		return nil, err
 	}
-	i := uint(f)
 	return &i, nil
 }
 
@@ -151,7 +150,7 @@ func unmarshalQueryDetail(val interface{}) (QueryDetails, error) {
 	if !ok {
 		return result, errors.New("argument was missing or the wrong type")
 	}
-	interval, err := unmarshalInterval(v["interval"])
+	interval, err := unmarshalInteger(v["interval"])
 	if err != nil {
 		return result, err
 	}
@@ -181,7 +180,7 @@ func unmarshalQueryDetail(val interface{}) (QueryDetails, error) {
 	}
 	result = QueryDetails{
 		Query:    query,
-		Interval: interval,
+		Interval: OsQueryConfigInt(interval),
 		Removed:  removed,
 		Platform: platform,
 		Version:  version,
@@ -194,18 +193,18 @@ func unmarshalQueryDetail(val interface{}) (QueryDetails, error) {
 // It is valid for the interval can be a string that is convertable to an int,
 // or an float64. The float64 is how all numbers in JSON are represented, so
 // we need to convert to uint
-func unmarshalInterval(val interface{}) (uint, error) {
+func unmarshalInteger(val interface{}) (OsQueryConfigInt, error) {
 	// if interval is nil return zero value
 	if val == nil {
-		return uint(0), nil
+		return OsQueryConfigInt(0), nil
 	}
 	switch v := val.(type) {
 	case string:
 		i, err := strconv.ParseUint(v, 10, 64)
-		return uint(i), err
+		return OsQueryConfigInt(i), err
 	case float64:
-		return uint(v), nil
+		return OsQueryConfigInt(v), nil
 	default:
-		return uint(0), wrongTypeError
+		return OsQueryConfigInt(0), wrongTypeError
 	}
 }

--- a/server/service/endpoint_import_config_test.go
+++ b/server/service/endpoint_import_config_test.go
@@ -60,6 +60,30 @@ func testImportConfigWithMissingGlob(t *testing.T, r *testResource) {
 
 }
 
+func testImportConfigWithIntAsString(t *testing.T, r *testResource) {
+
+	testJSON := `
+  {
+    "config": "{\"options\":{\"host_identifier\":\"hostname\",\"schedule_splay_percent\":10},\"schedule\":{\"macosx_kextstat\":{\"query\":\"SELECT * FROM kernel_extensions;\",\"interval\":\"10\"},\"foobar\":{\"query\":\"SELECT foo, bar, pid FROM foobar_table;\",\"interval\":600}},\"packs\":{\"external_pack\":\"/path/to/external_pack.conf\",\"internal_pack\":{\"discovery\":[\"select pid from processes where name = 'foobar';\",\"select count(*) from users where username like 'www%';\"],\"platform\":\"linux\",\"version\":\"1.5.2\",\"queries\":{\"active_directory\":{\"query\":\"select * from ad_config;\",\"interval\":\"1200\",\"description\":\"Check each user's active directory cached settings.\"}}}},\"decorators\":{\"load\":[\"SELECT version FROM osquery_info\",\"SELECT uuid AS host_uuid FROM system_info\"],\"always\":[\"SELECT user AS username FROM logged_in_users WHERE user <> '' ORDER BY time LIMIT 1;\"],\"interval\":{\"3600\":[\"SELECT total_seconds AS uptime FROM uptime;\"]}},\"yara\":{\"signatures\":{\"sig_group_1\":[\"/Users/wxs/sigs/foo.sig\",\"/Users/wxs/sigs/bar.sig\"],\"sig_group_2\":[\"/Users/wxs/sigs/baz.sig\"]},\"file_paths\":{\"system_binaries\":[\"sig_group_1\"],\"tmp\":[\"sig_group_1\",\"sig_group_2\"]}},\"file_paths\":{\"system_binaries\":[\"/usr/bin/%\",\"/usr/sbin/%\"],\"tmp\":[\"/Users/%/tmp/%%\",\"/tmp/%\"]}}",
+    "external_pack_configs": {
+      "external_pack": "{\"discovery\":[\"select pid from processes where name = 'baz';\"],\"platform\":\"linux\",\"version\":\"1.5.2\",\"queries\":{\"something\":{\"query\":\"select * from something;\",\"interval\":1200,\"description\":\"Check something.\"}}}"
+    }
+  }
+  `
+	buff := bytes.NewBufferString(testJSON)
+	req, err := http.NewRequest("POST", r.server.URL+"/api/v1/kolide/osquery/config/import", buff)
+	require.Nil(t, err)
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.adminToken))
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	require.Nil(t, err)
+	var impResponse importResponse
+	err = json.NewDecoder(resp.Body).Decode(&impResponse)
+	require.Nil(t, err)
+	assert.Equal(t, 2, impResponse.Response.ImportStatusBySection[kolide.YARASigSection].ImportCount)
+	assert.Equal(t, 4, impResponse.Response.ImportStatusBySection[kolide.DecoratorsSection].ImportCount)
+}
+
 func testImportConfig(t *testing.T, r *testResource) {
 
 	testJSON := `

--- a/server/service/endpoint_test.go
+++ b/server/service/endpoint_test.go
@@ -110,6 +110,7 @@ var testFunctions = [...]func(*testing.T, *testResource){
 	testImportConfigMissingExternal,
 	testImportConfigWithMissingGlob,
 	testImportConfigWithGlob,
+	testImportConfigWithIntAsString,
 	testAdminUserSetAdmin,
 	testNonAdminUserSetAdmin,
 	testAdminUserSetEnabled,

--- a/server/service/service_import_config.go
+++ b/server/service/service_import_config.go
@@ -197,12 +197,12 @@ func (svc service) importScheduledQueries(uid uint, cfg *kolide.ImportConfig, re
 		sq := &kolide.ScheduledQuery{
 			PackID:   pack.ID,
 			QueryID:  query.ID,
-			Interval: queryDetails.Interval,
+			Interval: uint(queryDetails.Interval),
 			Snapshot: queryDetails.Snapshot,
 			Removed:  queryDetails.Removed,
 			Platform: queryDetails.Platform,
 			Version:  queryDetails.Version,
-			Shard:    queryDetails.Shard,
+			Shard:    configInt2Ptr(queryDetails.Shard),
 		}
 		_, err = svc.ds.NewScheduledQuery(sq)
 		if err != nil {
@@ -317,12 +317,12 @@ func (svc service) createQueriesForPack(uid uint, pack *kolide.Pack, details *ko
 		scheduledQuery := &kolide.ScheduledQuery{
 			PackID:   pack.ID,
 			QueryID:  query.ID,
-			Interval: queryDetails.Interval,
+			Interval: uint(queryDetails.Interval),
 			Platform: queryDetails.Platform,
 			Snapshot: queryDetails.Snapshot,
 			Removed:  queryDetails.Removed,
 			Version:  queryDetails.Version,
-			Shard:    queryDetails.Shard,
+			Shard:    configInt2Ptr(queryDetails.Shard),
 		}
 		_, err = svc.ds.NewScheduledQuery(scheduledQuery)
 		if err != nil {
@@ -418,4 +418,12 @@ func (svc service) importOptions(opts kolide.OptionNameToValueMap, resp *kolide.
 		}
 	}
 	return nil
+}
+
+func configInt2Ptr(ci *kolide.OsQueryConfigInt) *uint {
+	if ci == nil {
+		return nil
+	}
+	ui := uint(*ci)
+	return &ui
 }


### PR DESCRIPTION
Addresses #1365.  The interval value in an imported config can be a number or a string.  Evidently this is a valid OS query config.  I added code to handle both cases, and, if the value is a string, verify that the string can be converted to an unsigned integer.  