### PR TITLE
Fix Issue where saving same option value errs.

### DIFF
--- a/server/datastore/datastore_options_test.go
+++ b/server/datastore/datastore_options_test.go
@@ -54,13 +54,14 @@ func testOptions(t *testing.T, ds kolide.Datastore) {
 	require.Nil(t, err)
 	opt.SetValue(true)
 	err = ds.SaveOptions([]kolide.Option{*opt})
-	assert.Nil(t, err)
+	assert.NotNil(t, err)
 	// check that it didn't change
 	opt, err = ds.OptionByName("disable_distributed")
 	require.Nil(t, err)
 	require.False(t, opt.GetValue().(bool))
 
 	opt, _ = ds.OptionByName("aws_profile_name")
+	oldValue := opt.GetValue()
 	assert.False(t, opt.OptionSet())
 	opt.SetValue("zip")
 	opt2, _ = ds.OptionByName("disable_distributed")
@@ -70,11 +71,15 @@ func testOptions(t *testing.T, ds kolide.Datastore) {
 	// The aws access key option can be saved but because the disable_events can't
 	// be we want to verify that the whole transaction is rolled back
 	err = ds.SaveOptions(modList)
-	assert.Nil(t, err)
+	assert.NotNil(t, err)
 
 	opt2, err = ds.OptionByName("disable_distributed")
 	require.Nil(t, err)
 	assert.Equal(t, false, opt2.GetValue())
+	opt, err = ds.OptionByName("aws_profile_name")
+	require.Nil(t, err)
+	assert.Equal(t, oldValue, opt.GetValue())
+
 }
 
 func testOptionsToConfig(t *testing.T, ds kolide.Datastore) {

--- a/server/datastore/mysql/campaigns.go
+++ b/server/datastore/mysql/campaigns.go
@@ -49,9 +49,16 @@ func (d *Datastore) SaveDistributedQueryCampaign(camp *kolide.DistributedQueryCa
 		WHERE id = ?
 		AND NOT deleted
 	`
-	_, err := d.db.Exec(sqlStatement, camp.QueryID, camp.Status, camp.UserID, camp.ID)
+	result, err := d.db.Exec(sqlStatement, camp.QueryID, camp.Status, camp.UserID, camp.ID)
 	if err != nil {
 		return errors.Wrap(err, "updating distributed query campaign")
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "rows affected updating distributed query campaign")
+	}
+	if rowsAffected == 0 {
+		return notFound("DistributedQueryCampaign").WithID(camp.ID)
 	}
 
 	return nil

--- a/server/datastore/mysql/delete.go
+++ b/server/datastore/mysql/delete.go
@@ -10,7 +10,7 @@ func (d *Datastore) deleteEntity(dbTable string, id uint) error {
 	deleteStmt := fmt.Sprintf(
 		`
 		UPDATE %s SET deleted_at = ?, deleted = TRUE
-			WHERE id = ?
+			WHERE id = ? AND NOT deleted 
 	`, dbTable)
 	result, err := d.db.Exec(deleteStmt, d.clock.Now(), id)
 	if err != nil {

--- a/server/datastore/mysql/invites.go
+++ b/server/datastore/mysql/invites.go
@@ -107,11 +107,18 @@ func (d *Datastore) SaveInvite(i *kolide.Invite) error {
 	   name = ?, position = ?, token = ?
 		 WHERE id = ? AND NOT deleted
 	`
-	_, err := d.db.Exec(sql, i.InvitedBy, i.Email,
+	results, err := d.db.Exec(sql, i.InvitedBy, i.Email,
 		i.Admin, i.Name, i.Position, i.Token, i.ID,
 	)
 	if err != nil {
 		return errors.Wrap(err, "save invite")
+	}
+	rowsAffected, err := results.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "rows affected updating invite")
+	}
+	if rowsAffected == 0 {
+		return notFound("Invite").WithID(i.ID)
 	}
 
 	return nil

--- a/server/datastore/mysql/licenses.go
+++ b/server/datastore/mysql/licenses.go
@@ -14,9 +14,16 @@ func (ds *Datastore) RevokeLicense(revoked bool) error {
 			revoked = ?
 		WHERE id = 1
 	`
-	_, err := ds.db.Exec(sql, revoked)
+	results, err := ds.db.Exec(sql, revoked)
 	if err != nil {
 		return errors.Wrap(err, "updating license revoked")
+	}
+	rowsAffected, err := results.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "rows affected updating license revoked")
+	}
+	if rowsAffected == 0 {
+		return notFound("License").WithID(uint(1))
 	}
 	return nil
 }
@@ -64,9 +71,16 @@ func (ds *Datastore) SaveLicense(token, publicKey string) (*kolide.License, erro
 			` + "`key`" + ` = ?
 		 WHERE id = 1`
 
-	_, err := ds.db.Exec(sqlStatement, token, publicKey)
+	res, err := ds.db.Exec(sqlStatement, token, publicKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "saving license")
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return nil, errors.Wrap(err, "rows affected saving license")
+	}
+	if rowsAffected == 0 {
+		return nil, notFound("License").WithID(uint(1))
 	}
 	result, err := ds.License()
 	if err != nil {

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -255,7 +255,7 @@ func registerTLS(config config.MysqlConfig) error {
 // provided configuration.
 func generateMysqlConnectionString(conf config.MysqlConfig) string {
 	dsn := fmt.Sprintf(
-		"%s:%s@(%s)/%s?charset=utf8mb4&parseTime=true&loc=UTC",
+		"%s:%s@(%s)/%s?charset=utf8mb4&parseTime=true&loc=UTC&clientFoundRows=true",
 		conf.Username,
 		conf.Password,
 		conf.Address,

--- a/server/datastore/mysql/options.go
+++ b/server/datastore/mysql/options.go
@@ -44,9 +44,16 @@ func (d *Datastore) SaveOptions(opts []kolide.Option) (err error) {
 	}()
 
 	for _, opt := range opts {
-		_, err = txn.Exec(sqlStatement, opt.Value, opt.ID, opt.Type)
+		resultInfo, err := txn.Exec(sqlStatement, opt.Value, opt.ID, opt.Type)
 		if err != nil {
 			return errors.Wrap(err, "update options")
+		}
+		rowsMatched, err := resultInfo.RowsAffected()
+		if err != nil {
+			return errors.Wrap(err, "update options reading rows matched")
+		}
+		if rowsMatched == 0 {
+			return notFound("Option").WithID(opt.ID)
 		}
 	}
 	// If all the updates succeed, set the success flag, this will cause the

--- a/server/datastore/mysql/password_reset.go
+++ b/server/datastore/mysql/password_reset.go
@@ -30,9 +30,16 @@ func (d *Datastore) SavePasswordResetRequest(req *kolide.PasswordResetRequest) e
 			token = ?
 		WHERE id = ?
 	`
-	_, err := d.db.Exec(sqlStatement, req.ExpiresAt, req.UserID, req.Token, req.ID)
+	result, err := d.db.Exec(sqlStatement, req.ExpiresAt, req.UserID, req.Token, req.ID)
 	if err != nil {
 		return errors.Wrap(err, "updating password reset requests")
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "rows affected updating password reset requests")
+	}
+	if rows == 0 {
+		return notFound("PasswordResetRequest").WithID(req.ID)
 	}
 
 	return nil

--- a/server/datastore/mysql/scheduled_queries.go
+++ b/server/datastore/mysql/scheduled_queries.go
@@ -57,11 +57,17 @@ func (d *Datastore) SaveScheduledQuery(sq *kolide.ScheduledQuery) (*kolide.Sched
 			SET pack_id = ?, query_id = ?, ` + "`interval`" + ` = ?, snapshot = ?, removed = ?, platform = ?, version = ?, shard = ?
 			WHERE id = ? AND NOT deleted
 	`
-	_, err := d.db.Exec(query, sq.PackID, sq.QueryID, sq.Interval, sq.Snapshot, sq.Removed, sq.Platform, sq.Version, sq.Shard, sq.ID)
+	result, err := d.db.Exec(query, sq.PackID, sq.QueryID, sq.Interval, sq.Snapshot, sq.Removed, sq.Platform, sq.Version, sq.Shard, sq.ID)
 	if err != nil {
 		return nil, errors.Wrap(err, "saving a scheduled query")
 	}
-
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return nil, errors.Wrap(err, "rows affected saving a scheduled query")
+	}
+	if rows == 0 {
+		return nil, notFound("ScheduledQueries").WithID(sq.ID)
+	}
 	return sq, nil
 }
 

--- a/server/datastore/mysql/sessions.go
+++ b/server/datastore/mysql/sessions.go
@@ -97,10 +97,16 @@ func (d *Datastore) MarkSessionAccessed(session *kolide.Session) error {
 		accessed_at = ?
 		WHERE id = ?
 	`
-	_, err := d.db.Exec(sqlStatement, d.clock.Now(), session.ID)
+	results, err := d.db.Exec(sqlStatement, d.clock.Now(), session.ID)
 	if err != nil {
 		return errors.Wrap(err, "updating mark session as accessed")
 	}
-
+	rows, err := results.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "rows affected updating mark session accessed")
+	}
+	if rows == 0 {
+		return notFound("Session").WithID(session.ID)
+	}
 	return nil
 }

--- a/server/datastore/mysql/users.go
+++ b/server/datastore/mysql/users.go
@@ -101,11 +101,18 @@ func (d *Datastore) SaveUser(user *kolide.User) error {
 			position = ?
 		WHERE id = ?
 	`
-	_, err := d.db.Exec(sqlStatement, user.Username, user.Password,
+	result, err := d.db.Exec(sqlStatement, user.Username, user.Password,
 		user.Salt, user.Name, user.Email, user.Admin, user.Enabled,
 		user.AdminForcedPasswordReset, user.GravatarURL, user.Position, user.ID)
 	if err != nil {
 		return errors.Wrap(err, "save user")
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "rows affected save user")
+	}
+	if rows == 0 {
+		return notFound("User").WithID(user.ID)
 	}
 
 	return nil

--- a/server/service/endpoint_options_test.go
+++ b/server/service/endpoint_options_test.go
@@ -11,8 +11,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testGetOptions(t *testing.T, r *testResource) {
+func testOptionNotFound(t *testing.T, r *testResource) {
+	// id 6000 is not an actual option
+	inJson := `{"options":[
+  {"id":6000,"name":"aws_access_key_id","type":"string","value":"foo","read_only":false},
+  {"id":7,"name":"aws_firehose_period","type":"int","value":23,"read_only":false}]}`
+	buff := bytes.NewBufferString(inJson)
+	req, err := http.NewRequest("PATCH", r.server.URL+"/api/v1/kolide/options", buff)
+	require.Nil(t, err)
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.adminToken))
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	require.Nil(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
 
+func testGetOptions(t *testing.T, r *testResource) {
 	req, err := http.NewRequest("GET", r.server.URL+"/api/v1/kolide/options", nil)
 	require.Nil(t, err)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.adminToken))

--- a/server/service/endpoint_test.go
+++ b/server/service/endpoint_test.go
@@ -106,6 +106,7 @@ var testFunctions = [...]func(*testing.T, *testResource){
 	testGetOptions,
 	testModifyOptions,
 	testModifyOptionsValidationFail,
+	testOptionNotFound,
 	testImportConfig,
 	testImportConfigMissingExternal,
 	testImportConfigWithMissingGlob,

--- a/server/service/service_options.go
+++ b/server/service/service_options.go
@@ -14,14 +14,14 @@ const minimumExpectedCheckinInterval = 10 * time.Second
 func (svc service) GetOptions(ctx context.Context) ([]kolide.Option, error) {
 	opts, err := svc.ds.ListOptions()
 	if err != nil {
-		return nil, errors.Wrap(err, "options service")
+		return nil, err
 	}
 	return opts, nil
 }
 
 func (svc service) ModifyOptions(ctx context.Context, req kolide.OptionRequest) ([]kolide.Option, error) {
 	if err := svc.ds.SaveOptions(req.Options); err != nil {
-		return nil, errors.Wrap(err, "modify options service")
+		return nil, err
 	}
 	return req.Options, nil
 }


### PR DESCRIPTION
Addresses issue https://github.com/kolide/kolide/issues/1390

On investigating this issue further, it became apparent that there were quite a few places where UPDATES could fail silently because we weren't checking that target rows where actually found where we expect them to be.  In order to address this problem  [clientFoundRows](https://github.com/go-sql-driver/mysql#clientfoundrows) was set in the sql driver configuration and checks for UPDATES were added to determine if matched rows were found where we expect them to be.  