### PR TITLE
Enable slow query log on dev DBs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: mysql:5.7
     volumes:
       - .:/tmp
-    command: mysqld --datadir=/tmp/mysqldata
+    command: mysqld --datadir=/tmp/mysqldata --slow_query_log=1 --log_output=TABLE --log-queries-not-using-indexes
     environment:
       MYSQL_ROOT_PASSWORD: toor
       MYSQL_DATABASE: kolide
@@ -15,7 +15,7 @@ services:
 
   mysql_test:
     image: mysql:5.7
-    command: mysqld --datadir=/tmpfs
+    command: mysqld --datadir=/tmpfs  --slow_query_log=1 --log_output=TABLE --log-queries-not-using-indexes
     tmpfs: /tmpfs
     environment:
       MYSQL_ROOT_PASSWORD: toor


### PR DESCRIPTION
With this change, MySQL will log "slow" queries to the `mysql.slow_log` table.