### PR TITLE
Remove extraneous calls to MarkHostSeen

### DIFF
--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -152,11 +152,6 @@ func (svc service) GetClientConfig(ctx context.Context) (*kolide.OsqueryConfig, 
 }
 
 func (svc service) SubmitStatusLogs(ctx context.Context, logs []kolide.OsqueryStatusLog) error {
-	_, ok := hostctx.FromContext(ctx)
-	if !ok {
-		return osqueryError{message: "internal error: missing host from request context"}
-	}
-
 	for _, log := range logs {
 		err := json.NewEncoder(svc.osqueryStatusLogWriter).Encode(log)
 		if err != nil {
@@ -168,11 +163,6 @@ func (svc service) SubmitStatusLogs(ctx context.Context, logs []kolide.OsquerySt
 }
 
 func (svc service) SubmitResultLogs(ctx context.Context, logs []kolide.OsqueryResultLog) error {
-	_, ok := hostctx.FromContext(ctx)
-	if !ok {
-		return osqueryError{message: "internal error: missing host from request context"}
-	}
-
 	for _, log := range logs {
 		err := json.NewEncoder(svc.osqueryResultLogWriter).Encode(log)
 		if err != nil {

--- a/server/service/service_osquery_test.go
+++ b/server/service/service_osquery_test.go
@@ -95,17 +95,10 @@ func TestSubmitStatusLogs(t *testing.T) {
 	require.Nil(t, err)
 	require.Len(t, hosts, 1)
 	host := hosts[0]
+	ctx = hostctx.NewContext(ctx, *host)
 
 	// Hack to get at the service internals and modify the writer
 	serv := ((svc.(validationMiddleware)).Service).(service)
-
-	// Error due to missing host
-	err = serv.SubmitResultLogs(ctx, []kolide.OsqueryResultLog{})
-	require.NotNil(t, err)
-	assert.Contains(t, err.Error(), "missing host")
-
-	// Add that host
-	ctx = hostctx.NewContext(ctx, *host)
 
 	var statusBuf bytes.Buffer
 	serv.osqueryStatusLogWriter = &statusBuf
@@ -145,16 +138,10 @@ func TestSubmitResultLogs(t *testing.T) {
 	require.Nil(t, err)
 	require.Len(t, hosts, 1)
 	host := hosts[0]
+	ctx = hostctx.NewContext(ctx, *host)
 
 	// Hack to get at the service internals and modify the writer
 	serv := ((svc.(validationMiddleware)).Service).(service)
-
-	// Error due to missing host
-	err = serv.SubmitResultLogs(ctx, []kolide.OsqueryResultLog{})
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "missing host")
-
-	ctx = hostctx.NewContext(ctx, *host)
 
 	var resultBuf bytes.Buffer
 	serv.osqueryResultLogWriter = &resultBuf


### PR DESCRIPTION
The seen time should only be updated once per request from the osquery agent to
the Kolide server. We now do that only in AuthenticateHost (which every request
besides enrollment must go through).