### PR TITLE
Fixed sidebar so config item only shows up for admin users.

### DIFF
--- a/frontend/components/side_panels/SiteNavSidePanel/navItems.js
+++ b/frontend/components/side_panels/SiteNavSidePanel/navItems.js
@@ -1,6 +1,15 @@
 export default (admin) => {
   const adminNavItems = [
     {
+      icon: 'config',
+      name: 'Config',
+      location: {
+        regex: /^\/config/,
+        pathname: '/config/options',
+      },
+      subItems: [],
+    },
+    {
       icon: 'admin',
       name: 'Admin',
       location: {
@@ -89,15 +98,6 @@ export default (admin) => {
           },
         },
       ],
-    },
-    {
-      icon: 'config',
-      name: 'Config',
-      location: {
-        regex: /^\/config/,
-        pathname: '/config/options',
-      },
-      subItems: [],
     },
     {
       icon: 'help',


### PR DESCRIPTION
Addresses https://github.com/kolide/kolide/issues/1395

The Config sidebar item should not show up at all for regular users as on the back end, only admin users can perform operations on osquery config options. 