### PR TITLE
Fixed problem where changed port didn't validate

### DIFF
--- a/frontend/app_constants/APP_SETTINGS.js
+++ b/frontend/app_constants/APP_SETTINGS.js
@@ -1,3 +1,4 @@
 export default {
   FAKE_PASSWORD: '********',
+  DEFAULT_SMTP_PORT: '587',
 };

--- a/frontend/components/forms/admin/AppConfigForm/validate.js
+++ b/frontend/components/forms/admin/AppConfigForm/validate.js
@@ -35,7 +35,9 @@ export default (formData) => {
     errors.org_name = 'Organization Name must be present';
   }
 
-  if (some([smtpSenderAddress, smtpServer, smtpUserName]) || (smtpPassword && smtpPassword !== APP_SETTINGS.FAKE_PASSWORD)) {
+  if (some([smtpSenderAddress, smtpServer, smtpUserName]) ||
+    (smtpPassword && smtpPassword !== APP_SETTINGS.FAKE_PASSWORD) ||
+    (smtpServerPort !== APP_SETTINGS.DEFAULT_SMTP_PORT)) {
     if (!smtpSenderAddress) {
       errors.sender_address = 'SMTP Sender Address must be present';
     }

--- a/frontend/components/forms/admin/AppConfigForm/validate.tests.js
+++ b/frontend/components/forms/admin/AppConfigForm/validate.tests.js
@@ -10,7 +10,7 @@ describe('AppConfigForm - validations', () => {
     license: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ',
     sender_address: 'hi@gnar.dog',
     server: '192.168.99.100',
-    port: 1025,
+    port: '1025',
     user_name: 'gnardog',
     password: 'p@ssw0rd',
   };
@@ -146,13 +146,14 @@ describe('AppConfigForm - validations', () => {
       });
     });
 
-    it('does not validate smtp config if only password is present and it is the fake password', () => {
+    it('does not validate smtp config if only password and port are present and they are defaults', () => {
       const formData = {
         ...validFormData,
         user_name: '',
         server: '',
         sender_address: '',
         password: '********',
+        port: '587',
       };
       const invalidFormData = {
         ...validFormData,
@@ -160,6 +161,11 @@ describe('AppConfigForm - validations', () => {
         server: '',
         sender_address: '',
         password: 'newPassword',
+        port: '587',
+      };
+      const missingPortFormData = {
+        ...validFormData,
+        port: '',
       };
 
       expect(validate(formData)).toEqual({
@@ -173,6 +179,13 @@ describe('AppConfigForm - validations', () => {
           sender_address: 'SMTP Sender Address must be present',
           server: 'SMTP Server must be present',
           user_name: 'SMTP Username must be present',
+        },
+      });
+
+      expect(validate(missingPortFormData)).toEqual({
+        valid: false,
+        errors: {
+          server: 'SMTP Server Port must be present',
         },
       });
     });


### PR DESCRIPTION
Closes issue https://github.com/kolide/kolide/issues/1380

In this case, skipped validation caused garbage data to get sent to the server which caused an error in the transport middleware. Note that there was another error referenced in the comments in the original issue that is a separate problem and hence will be addressed separately. 