### PR TITLE
use stdlib context in go-kit methods

### DIFF
--- a/server/service/endpoint_decorators.go
+++ b/server/service/endpoint_decorators.go
@@ -1,9 +1,10 @@
 package service
 
 import (
+	"context"
+
 	"github.com/go-kit/kit/endpoint"
 	"github.com/kolide/kolide/server/kolide"
-	"golang.org/x/net/context"
 )
 
 type listDecoratorResponse struct {

--- a/server/service/transport_decorators.go
+++ b/server/service/transport_decorators.go
@@ -1,10 +1,9 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
-
-	"golang.org/x/net/context"
 )
 
 func decodeNewDecoratorRequest(ctx context.Context, req *http.Request) (interface{}, error) {


### PR DESCRIPTION
This pull request updates the `x/net/context` imports to `context`. 

#1430 broke the build because the dependencies on master changed while the pull request was open. The PR builds relied on the old version of the glide lock file, so CI didn't break until the changes were merged on master.

To minimize these kinds of issues, we should rebase active PRs at the very least daily. 