### PR TITLE
fix gcloud deployment on CircleCI

### DIFF
--- a/tools/ci/deploy-k8s-testing.sh
+++ b/tools/ci/deploy-k8s-testing.sh
@@ -40,7 +40,8 @@ copy_db() {
         -p${CLOUDSQL_PASS} \
         --user=${CLOUDSQL_USER} \
         -h 127.0.0.1 \
-        --port=3310 kolide_master| \
+        --port=3310 \
+        --set-gtid-purged=OFF kolide_master| \
         mysql -p${CLOUDSQL_PASS} \
         --user=${CLOUDSQL_USER} \
         -h 127.0.0.1 \
@@ -69,11 +70,11 @@ deploy_pr() {
     $exec_template -json="$jsn" -template=./tools/ci/k8s-templates/redis-pr-service.template > /tmp/redis-service.yml
     $exec_template -json="$jsn" -template=./tools/ci/k8s-templates/redis-pr-deployment.template > /tmp/redis-deployment.yml
 
-    sudo $kubectl apply -f /tmp/service.yml
-    sudo $kubectl apply -f /tmp/deployment.yml
+    $kubectl apply -f /tmp/service.yml
+    $kubectl apply -f /tmp/deployment.yml
 
-    sudo $kubectl apply -f /tmp/redis-service.yml
-    sudo $kubectl apply -f /tmp/redis-deployment.yml
+    $kubectl apply -f /tmp/redis-service.yml
+    $kubectl apply -f /tmp/redis-deployment.yml
 
     echo "Deployed PR ${CIRCLE_PR_NUMBER}, commit ${CIRCLE_SHA1}" | \
         $slacktee \
@@ -92,8 +93,8 @@ deploy_branch() {
     $exec_template -json="$jsn" -template=./tools/ci/k8s-templates/branch-service.template > /tmp/service.yml
     $exec_template -json="$jsn" -template=./tools/ci/k8s-templates/branch-deployment.template > /tmp/deployment.yml
 
-    sudo $kubectl apply -f /tmp/deployment.yml
-    sudo $kubectl apply -f /tmp/service.yml
+    $kubectl apply -f /tmp/deployment.yml
+    $kubectl apply -f /tmp/service.yml
 
     echo "Deployed Branch ${branch}, commit ${CIRCLE_SHA1}" | \
         $slacktee \

--- a/tools/ci/setup-build-environment.sh
+++ b/tools/ci/setup-build-environment.sh
@@ -12,6 +12,7 @@ setup_gcloud() {
     sudo /opt/google-cloud-sdk/bin/gcloud --quiet container clusters get-credentials $CLUSTER_NAME
 
     sudo chown -R ubuntu:ubuntu /home/ubuntu/.kube
+    sudo chown -R ubuntu:ubuntu /home/ubuntu/.config
 }
 
 


### PR DESCRIPTION
Earlier this week an update from `gcloud` broke deployments. 
see: https://discuss.circleci.com/t/google-container-engine-deployment-fails/11690

This appears to be fixed now, and I changed the permissions accordingly, undoing some of the work in https://github.com/kolide/kolide/pull/1477/files 

Coincidentally the mysql command stopped working (likely due to one of our migrations). Setting the 
```
--set-gtid-purged=OFF
``` 
allowed mysqldump to succeed again. I had a similar issue in kolide/cloud early on, but until recently the kolide db did not require that flag. 