### PR TITLE
PoC for setting session token and redirecting from Go

### DIFF
--- a/server/service/endpoint_sessions.go
+++ b/server/service/endpoint_sessions.go
@@ -9,6 +9,36 @@ import (
 )
 
 ////////////////////////////////////////////////////////////////////////////////
+// SubmitAuthnResponse
+////////////////////////////////////////////////////////////////////////////////
+
+type submitAuthnResponseRequest struct {
+	AuthnResponse string
+
+	// These params only here for testing, normally the token would be
+	// generated and the redirect URL would come from Redis
+	Token       string
+	RedirectURL string
+}
+
+type submitAuthnResponseResponse struct {
+	Token       string
+	RedirectURL string
+	Err         error
+}
+
+func (r submitAuthnResponseResponse) error() error { return r.Err }
+
+func makeSubmitAuthnResponseEndpoint(svc kolide.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(submitAuthnResponseRequest)
+		// Verify response, create token, etc. here
+
+		return submitAuthnResponseResponse{req.Token, req.RedirectURL, nil}, nil
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // Login
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
PoC for how the backend might set the auth token in the JS and redirect the frontend to the originally requested page after successful SSO auth.

Note that the redirect URL and token are only taken as request parameters here for testing purposes. In a regular SAML SSO exchange, a new session token would be generated, and the redirect URL would be pulled from Redis along with the other request metadata.

To try this out:
1. Log into the Kolide instance.
2. Retrieve the session token: open the JS console and enter `window.localStorage.getItem('KOLIDE::auth_token')`.
3. Open an incognito window and navigate to the redirect URL with the appropriate params filled in (eg. `https://localhost:8080/api/v1/kolide/sso/response?token=long_jwt_token&redirect_url=/packs/manage`)

Also note that you will be booted back to the login screen by the frontend if you provide an invalid token.