### PR TITLE
Add ability to handle empty set of decorators

### DIFF
--- a/frontend/pages/decorators/ManageDecoratorsPage/ManageDecoratorsPage.jsx
+++ b/frontend/pages/decorators/ManageDecoratorsPage/ManageDecoratorsPage.jsx
@@ -11,7 +11,7 @@ import decoratorInterface from 'interfaces/decorators';
 import entityGetter from 'redux/utilities/entityGetter';
 import { renderFlash } from 'redux/nodes/notifications/actions';
 import paths from 'router/paths';
-import { pull, get } from 'lodash';
+import { pull, get, isEmpty } from 'lodash';
 
 
 const baseClass = 'manage-decorators-page';
@@ -239,7 +239,8 @@ export class ManageDecoratorsPage extends Component {
 
 const mapStateToProps = (state, { location }) => {
   const decoratorEntities = entityGetter(state).get('decorators');
-  const { entities: decorators } = decoratorEntities;
+  let { entities: decorators } = decoratorEntities;
+  decorators = decorators.filter((decorator) => { return !isEmpty(decorator); });
   const selectedDecoratorID = get(location, 'query.selectedDecorator');
   const selectedDecorator = selectedDecoratorID && decoratorEntities.findBy({ id: selectedDecoratorID });
   return { decorators, selectedDecorator };

--- a/server/service/endpoint_decorators.go
+++ b/server/service/endpoint_decorators.go
@@ -8,7 +8,7 @@ import (
 )
 
 type listDecoratorResponse struct {
-	Decorators []*kolide.Decorator `json:"decorators,omitempty"`
+	Decorators []*kolide.Decorator `json:"decorators"`
 	Err        error               `json:"error,omitempty"`
 }
 


### PR DESCRIPTION
Normally a Kolide user will always have at least two built in decorators that they can't delete through the UI so a situation with zero decorators should never happen; however, in the event we change this behavior in the future, or a user manually deletes decorators from the database the UI should handle an empty decorator set. 