### PR TITLE
Fix aliased config_tls_refresh processing

### DIFF
--- a/server/service/service_osquery_test.go
+++ b/server/service/service_osquery_test.go
@@ -696,6 +696,10 @@ func TestDetailQueries(t *testing.T) {
       "value":"10"
     },
     {
+      "name":"config_refresh",
+      "value":"9"
+    },
+    {
       "name":"distributed_interval",
       "value":"5"
     },


### PR DESCRIPTION
Changes in osquery 2.4.6 prevented us from correctly retrieving the config
interval. This commit retrieves the new aliased interval.