### PR TITLE
Base64 encoded SAML entity ID causes problem in ADFS 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Fixed issue that caused ADFS single sign on to fail on certain SAML request ID's. 
+
+* Fixed issue validating signatures in nested SAML assertions.
+
 ## Kolide 1.0.4 (Jun 1, 2017)
 
 * Added feature that allows users to import existing Osquery configuration files using the [configimporter](https://github.com/kolide/configimporter) utility.
@@ -22,7 +26,7 @@
 
 * Fixed issue where heavily loaded database caused host authentication failures.
 
-* Fixed issue where osquery sends empty strings for integer values in log results. 
+* Fixed issue where osquery sends empty strings for integer values in log results.
 
 ## Kolide 1.0.3 (April 3, 2017)
 

--- a/glide.lock
+++ b/glide.lock
@@ -14,7 +14,7 @@ imports:
   subpackages:
   - quantile
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: adab96458c51a58dc1783b3335dcce5461522e75
   subpackages:
   - spew
 - name: github.com/dgrijalva/jwt-go
@@ -151,7 +151,7 @@ imports:
 - name: github.com/spf13/viper
   version: 7fb2782df3d83e0036cc89f461ed0422628776f4
 - name: github.com/stretchr/testify
-  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  version: 05e8a0eda380579888eb53c394909df027f06991
   subpackages:
   - assert
   - require

--- a/server/sso/authorization_request.go
+++ b/server/sso/authorization_request.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/kolide/fleet/server/kolide"
 	"github.com/pkg/errors"
 )
 
@@ -39,7 +38,7 @@ func CreateAuthorizationRequest(settings *Settings, issuer string, options ...fu
 	if settings.Metadata == nil {
 		return "", errors.New("missing settings metadata")
 	}
-	requestID, err := kolide.RandomText(16)
+	requestID, err := generateSAMLValidID()
 	if err != nil {
 		return "", errors.Wrap(err, "creating auth request id")
 	}
@@ -57,7 +56,6 @@ func CreateAuthorizationRequest(settings *Settings, issuer string, options ...fu
 		AssertionConsumerServiceURL: settings.AssertionConsumerServiceURL,
 		Destination:                 destinationURL,
 		IssueInstant:                time.Now().UTC().Format("2006-01-02T15:04:05Z"),
-		ProtocolBinding:             RedirectBinding,
 		Version:                     samlVersion,
 		ProviderName:                "Kolide",
 		Issuer: Issuer{

--- a/server/sso/validate.go
+++ b/server/sso/validate.go
@@ -1,6 +1,7 @@
 package sso
 
 import (
+	"crypto/rand"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/xml"
@@ -164,4 +165,24 @@ func (v *validator) validateAssertionSignature(elt *etree.Element) error {
 		return nil
 	}
 	return etreeutils.NSFindIterate(elt, "urn:oasis:names:tc:SAML:2.0:assertion", "Assertion", validateAssertion)
+}
+
+const (
+	idSize     = 16
+	idAlphabet = `1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ`
+)
+
+// There isn't anything in the SAML spec that tells us what is valid inside an ID
+// other than expecting that it has to be unique and valid XML. ADFS blows up on '=' in the ID,
+// so we are using an alphabet that we know works.
+func generateSAMLValidID() (string, error) {
+	randomBytes := make([]byte, idSize)
+	_, err := rand.Read(randomBytes)
+	if err != nil {
+		return "", err
+	}
+	for i := 0; i < idSize; i++ {
+		randomBytes[i] = idAlphabet[randomBytes[i]%byte(len(idAlphabet))]
+	}
+	return string(randomBytes), nil
 }

--- a/server/sso/validate_test.go
+++ b/server/sso/validate_test.go
@@ -174,3 +174,16 @@ func TestVerifyInvalidSignatureGoogleResponse(t *testing.T) {
 	_, err = validator.ValidateSignature(auth)
 	require.NotNil(t, err)
 }
+
+// validate id's are unique and that I didn't screw up my maths
+func TestIDGenerator(t *testing.T) {
+	idTable := make(map[string]struct{})
+	for i := 0; i < 100; i++ {
+		id, err := generateSAMLValidID()
+		require.Nil(t, err)
+		assert.Subset(t, []byte(idAlphabet), []byte(id))
+		_, ok := idTable[id]
+		assert.False(t, ok)
+		idTable[id] = struct{}{}
+	}
+}


### PR DESCRIPTION
Closes https://github.com/kolide/fleet/issues/1533

Since the SAML 2.0 spec doesn't say what characters are valid in an Entity ID and Active Directory doesn't like '=' signs in base64 encoded ID's I added code that generates ID's with a character set that we know works. 