### PR TITLE
Attribute shouldn't appear in request if empty.

### DIFF
--- a/server/sso/types.go
+++ b/server/sso/types.go
@@ -12,7 +12,7 @@ type AuthnRequest struct {
 	SAMLSIG                     string                 `xml:"xmlns:samlsig,attr,omitempty"`
 	ID                          string                 `xml:"ID,attr"`
 	Version                     string                 `xml:"Version,attr"`
-	ProtocolBinding             string                 `xml:"ProtocolBinding,attr"`
+	ProtocolBinding             string                 `xml:"ProtocolBinding,attr,omitempty"`
 	AssertionConsumerServiceURL string                 `xml:"AssertionConsumerServiceURL,attr"`
 	Destination                 string                 `xml:"Destination,attr"`
 	IssueInstant                string                 `xml:"IssueInstant,attr"`


### PR DESCRIPTION
ProtocolBinding is an optional attribute in the SAML spec, and shouldn't appear in the request xml if it is not populated. 