### PR TITLE
Corrects issue where a stale query is executed instead of current query. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 * Added FIM support 
 
+* Title on query page correctly reflects new or edit mode. 
+
+* Fixed issue on new query page where last query would be submitted instead of current.
+
 * Fixed issue where user menu did not work on Firefox browser
 
 * Fixed issue cause SSO to fail for ADFS

--- a/frontend/components/forms/queries/QueryForm/QueryForm.jsx
+++ b/frontend/components/forms/queries/QueryForm/QueryForm.jsx
@@ -45,6 +45,7 @@ class QueryForm extends Component {
     onOsqueryTableSelect: PropTypes.func,
     onUpdate: PropTypes.func,
     queryIsRunning: PropTypes.bool,
+    title: PropTypes.string,
   };
 
   static defaultProps = {
@@ -135,13 +136,13 @@ class QueryForm extends Component {
   }
 
   render () {
-    const { baseError, fields, handleSubmit, queryIsRunning } = this.props;
+    const { baseError, fields, handleSubmit, queryIsRunning, title } = this.props;
     const { errors } = this.state;
     const { onLoad, renderButtons } = this;
 
     return (
       <form className={`${baseClass}__wrapper`} onSubmit={handleSubmit}>
-        <h1>New Query</h1>
+        <h1>{title}</h1>
         {baseError && <div className="form__base-error">{baseError}</div>}
         <InputField
           {...fields.name}

--- a/frontend/pages/queries/QueryPage/QueryPage.jsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.jsx
@@ -57,6 +57,7 @@ export class QueryPage extends Component {
     selectedHosts: PropTypes.arrayOf(hostInterface),
     selectedOsqueryTable: osqueryTableInterface,
     selectedTargets: PropTypes.arrayOf(targetInterface),
+    title: PropTypes.string,
   };
 
   static defaultProps = {
@@ -97,9 +98,11 @@ export class QueryPage extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    const { dispatch, location, selectedHosts, selectedTargets } = nextProps;
+    const { dispatch, location, query, selectedHosts, selectedTargets } = nextProps;
     const nextPathname = location.pathname;
     const { pathname } = this.props.location;
+    const { query: queryText } = query;
+    this.setState({ queryText });
 
     if (nextPathname !== pathname) {
       this.resetCampaignAndTargets();
@@ -519,6 +522,7 @@ export class QueryPage extends Component {
       loadingQueries,
       query,
       selectedOsqueryTable,
+      title,
     } = this.props;
 
     if (loadingQueries) {
@@ -540,6 +544,7 @@ export class QueryPage extends Component {
               queryIsRunning={queryIsRunning}
               serverErrors={errors}
               selectedOsqueryTable={selectedOsqueryTable}
+              title={title}
             />
           </div>
           {renderTargetsInput()}
@@ -566,6 +571,7 @@ const mapStateToProps = (state, ownProps) => {
   const { selectedTargets } = state.components.QueryPages;
   const { host_ids: hostIDs } = ownProps.location.query;
   const { isSmallNav } = state.app;
+  const title = queryID ? 'Edit Query' : 'New Query';
   let selectedHosts = [];
 
   // hostIDs are URL params so they are strings
@@ -587,6 +593,7 @@ const mapStateToProps = (state, ownProps) => {
     selectedOsqueryTable,
     selectedHosts,
     selectedTargets,
+    title,
   };
 };
 


### PR DESCRIPTION
Closes #1540 

The component state of QueryPageSelectTargets was not assigned correctly, causing this problem.  This has been fixed. 