### PR TITLE
Remove references to public docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 ### Effective Endpoint Security. At Any Scale.
 
-Kolide Fleet is a state of the art host monitoring platform tailored for security experts. Leveraging Facebook's battle-tested osquery project, Kolide delivers fast answers to big questions. To learn more about the Kolide product, visit [https://kolide.co/product](https://kolide.co/product).
+Kolide Fleet is a state of the art host monitoring platform tailored for security experts. Leveraging Facebook's battle-tested osquery project, Kolide delivers fast answers to big questions. To learn more about the Kolide Fleet, visit [https://kolide.com/fleet](https://kolide.com/fleet).
 
-Documentation for Kolide can be found at [https://docs.kolide.co](https://docs.kolide.co/kolide/current/).
+Documentation for Kolide can be found on [GitHub](./docs/README.md).
 
-[![Kolide](./assets/images/rube.png)](https://kolide.co)
+[![Kolide](./assets/images/rube.png)](https://kolide.com/fleet)
 
-- Information about using the Kolide web application can be found in the [Application Documentation](https://docs.kolide.co/kolide/current/application/).
-- Resources for deploying osquery to hosts, deploying the Kolide server, installing Kolide's infrastructure dependencies, etc. can all be found in the [Infrastructure Documentation](https://docs.kolide.co/kolide/current/infrastructure/).
-- If you are interested in accessing the Kolide REST API in order to programmatically interact with your osquery installation, please see the [API Documentation](https://docs.kolide.co/kolide/current/api/).
-- Finally, if you're interested in interacting with the Kolide source code, you will find information on modifying and building the code in the [Development Documentation](https://docs.kolide.co/kolide/current/development/).
+- Information about using the Kolide web application can be found in the [Application Documentation](./docs/application/README.md).
+- Resources for deploying osquery to hosts, deploying the Kolide server, installing Kolide's infrastructure dependencies, etc. can all be found in the [Infrastructure Documentation](./docs/infrastructure/README.md).
+- If you are interested in accessing the Kolide REST API in order to programmatically interact with your osquery installation, please see the [API Documentation](./docs/api/README.md).
+- Finally, if you're interested in interacting with the Kolide source code, you will find information on modifying and building the code in the [Development Documentation](./docs/development/README.md).
 
 If you have any questions, please don't hesitate to reach out to [support@kolide.co](mailto:support@kolide.co).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -5,7 +5,7 @@ The Kolide front-end is a Single Page Application using React and Redux.
 ## Running the Kolide web app
 
 For details instruction on building and serving the Kolide web application
-consult the [Development Documentation](https://docs.kolide.co/kolide/current/development/index.html)
+consult the [Development Documentation](./development/README.md)
 
 ## Directory Structure
 

--- a/frontend/components/hosts/AddHostModal/AddHostModal.jsx
+++ b/frontend/components/hosts/AddHostModal/AddHostModal.jsx
@@ -64,7 +64,7 @@ class AddHostModal extends Component {
         <div className={`${baseClass}__manual-install-content`}>
           <ol className={`${baseClass}__install-steps`}>
             <li>
-              <h4><a href="https://docs.kolide.co/kolide/current/infrastructure/adding-hosts-to-kolide.html" target="_blank" rel="noopener noreferrer">Kolide / Osquery - Install Docs <Icon name="external-link" /></a></h4>
+              <h4><a href="https://github.com/kolide/fleet/blob/master/docs/infrastructure/adding-hosts-to-fleet.md" target="_blank" rel="noopener noreferrer">Kolide / Osquery - Install Docs <Icon name="external-link" /></a></h4>
               <p>In order to install <strong>osquery</strong> on a client you will need the following information:</p>
             </li>
             <li>

--- a/frontend/components/side_panels/SiteNavSidePanel/navItems.js
+++ b/frontend/components/side_panels/SiteNavSidePanel/navItems.js
@@ -130,7 +130,7 @@ export default (admin) => {
       name: 'Help',
       location: {
         regex: /^\/help/,
-        pathname: 'https://docs.kolide.co/kolide/current/',
+        pathname: 'https://github.com/kolide/fleet/blob/master/docs/README.md',
       },
       subItems: [],
     },


### PR DESCRIPTION
With this being open source, we can hard link to markdown files, so there is no longer a need for the public https://docs.kolide.com site