### PR TITLE
Fix .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
 *
-!build/fleet
+!./build/linux


### PR DESCRIPTION
An incorrect entry in the dockerignore file led to the build context not
including the necessary binary.