### PR TITLE
Remove support for apt and yum repositories

### DIFF
--- a/docs/infrastructure/fleet-on-centos.md
+++ b/docs/infrastructure/fleet-on-centos.md
@@ -21,8 +21,9 @@ $ vagrant ssh
 To install Fleet, run the following:
 
 ```
-$ sudo rpm -ivh https://dl.kolide.co/yum/kolide-yum-repo-1.0.0-1.noarch.rpm
-$ sudo yum install fleet
+$ wget https://dl.kolide.co/bin/fleet_latest.zip
+$ unzip fleet_latest.zip 'linux/*' -d fleet
+$ sudo cp fleet/linux/fleet /usr/bin/fleet
 ```
 
 ## Installing and configuring dependencies

--- a/docs/infrastructure/fleet-on-ubuntu.md
+++ b/docs/infrastructure/fleet-on-ubuntu.md
@@ -21,10 +21,9 @@ $ vagrant ssh
 To install Fleet, run the following:
 
 ```
-$ wget -qO - https://dl.kolide.co/archive.key | sudo apt-key add -
-$ sudo add-apt-repository "deb https://dl.kolide.co/apt jessie main"
-$ sudo apt-get update
-$ sudo apt-get install fleet
+$ wget https://dl.kolide.co/bin/fleet_latest.zip
+$ unzip fleet_latest.zip 'linux/*' -d fleet
+$ sudo cp fleet/linux/fleet /usr/bin/fleet
 ```
 
 ## Installing and configuring dependencies

--- a/docs/infrastructure/installing-fleet.md
+++ b/docs/infrastructure/installing-fleet.md
@@ -27,42 +27,6 @@ docker pull kolide/fleet
 
 For more information on using Fleet, refer to the [Configuring The Fleet Binary](./configuring-the-fleet-binary.md) documentation.
 
-#### Debian Packages (Ubuntu, Debian)
-
-Add our GPG key and install the Kolide Apt Repository:
-
-```
-wget -qO - https://dl.kolide.co/archive.key | sudo apt-key add -
-sudo add-apt-repository "deb https://dl.kolide.co/apt jessie main"
-sudo apt-get update
-```
-
-Install Fleet:
-
-```
-sudo apt-get install fleet
-/usr/bin/fleet --help
-```
-
-For more information on using Fleet, refer to the [Configuring The Fleet Binary](./configuring-the-fleet-binary.md) documentation.
-
-#### Yum Packages (CentOS, RHEL, Amazon Linux)
-
-Install the Kolide Yum Repository:
-
-```
-sudo rpm -ivh https://dl.kolide.co/yum/kolide-yum-repo-1.0.0-1.noarch.rpm
-```
-
-Install Fleet:
-
-```
-sudo yum install fleet
-fleet --help
-```
-
-For more information on using Fleet, refer to the [Configuring The Fleet Binary](./configuring-the-fleet-binary.md) documentation.
-
 #### Raw binaries
 
 Download the latest raw Fleet binaries:

--- a/docs/infrastructure/updating-fleet.md
+++ b/docs/infrastructure/updating-fleet.md
@@ -32,22 +32,6 @@ Pull the latest Fleet docker image:
 docker pull kolide/fleet
 ```
 
-#### Debian Packages (Ubuntu, Debian)
-
-Update Fleet through the Apt repository (the repository should have been added during initial install):
-
-```
-sudo apt-get update && sudo apt-get install fleet
-```
-
-#### Yum Packages (CentOS, RHEL, Amazon Linux)
-
-Update Fleet through the Yum respository (the repository should have been added during initial install):
-
-```
-sudo yum update fleet
-```
-
 #### Raw binaries
 
 Download the latest raw Fleet binaries:


### PR DESCRIPTION
@groob and I paired on this today and we came to the conclusion that the current tooling that we have for managing Linux packages is fifty shades of jank. We agreed that it was best to not support `fleet` apt and yum repositories for the time being. I think that we should gauge interest in the community and try to prioritize linux package repositories vs a fleet autoupdater (we could do this with https://notary.kolide.com rather easily).

This PR update the documentation to remove references to the packages and, instead, offers alternative solutions to the problems in each document.