### PR TITLE
expose the host authentication middleware

### DIFF
--- a/server/service/endpoint_middleware_test.go
+++ b/server/service/endpoint_middleware_test.go
@@ -206,9 +206,7 @@ func TestAuthenticatedHost(t *testing.T) {
 
 	endpoint := authenticatedHost(
 		svc,
-		func(ctx context.Context, request interface{}) (interface{}, error) {
-			return nil, nil
-		},
+		endpoint.Nop,
 	)
 
 	ctx := context.Background()


### PR DESCRIPTION
Allows both launcher and tls endpoints to share the same authentication middleware.

This change would be used in #1571 