### PR TITLE
Fix issue in which default query runs instead of entered query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed bug in which default query was run instead of entered query.
+
 * Added pagination to the Host browser pages for increased performance.
 
 * Fixed bug rendering hosts when clock speed cannot be parsed.

--- a/frontend/pages/queries/QueryPage/QueryPage.jsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.jsx
@@ -98,11 +98,9 @@ export class QueryPage extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    const { dispatch, location, query, selectedHosts, selectedTargets } = nextProps;
+    const { dispatch, location, selectedHosts, selectedTargets } = nextProps;
     const nextPathname = location.pathname;
     const { pathname } = this.props.location;
-    const { query: queryText } = query;
-    this.setState({ queryText });
 
     if (nextPathname !== pathname) {
       this.resetCampaignAndTargets();


### PR DESCRIPTION
Verified to work in the following scenarios:
- Saved query loaded and run
- Saved query loaded, edited, and run
- New query edited and run

Closes #1611