### PR TITLE
Fixed leaking http client

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -68,7 +68,7 @@
 
 [[projects]]
   name = "github.com/go-kit/kit"
-  packages = ["endpoint","log","log/level","metrics","metrics/internal/lv","metrics/prometheus","transport/grpc","transport/http"]
+  packages = ["endpoint","log","metrics","metrics/internal/lv","metrics/prometheus","transport/grpc","transport/http"]
   revision = "4dc7be5d2d12881735283bcab7352178e190fc71"
   version = "v0.6.0"
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -68,7 +68,7 @@
 
 [[projects]]
   name = "github.com/go-kit/kit"
-  packages = ["endpoint","log","metrics","metrics/internal/lv","metrics/prometheus","transport/grpc","transport/http"]
+  packages = ["endpoint","log","log/level","metrics","metrics/internal/lv","metrics/prometheus","transport/grpc","transport/http"]
   revision = "4dc7be5d2d12881735283bcab7352178e190fc71"
   version = "v0.6.0"
 
@@ -159,7 +159,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/kolide/kit"
-  packages = ["version"]
+  packages = ["logutil","version"]
   revision = "566c8f56a6ff7daba204818fbab0f2cb854b3310"
 
 [[projects]]
@@ -351,6 +351,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c4fd9d0e72067244e44c5d04e91a4af2830b38e3609e8984aa24e1c1337286c2"
+  inputs-digest = "5877e27609b4ef9a90b6400074eed01a3702ac3a2afc8b3c5fe1eb76ca3a6592"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -14,7 +14,9 @@ import (
 	"github.com/kolide/fleet/server/kolide"
 	"github.com/kolide/fleet/server/logwriter"
 	"github.com/kolide/fleet/server/sso"
-	lumberjack "gopkg.in/natefinch/lumberjack.v2"
+	"gopkg.in/natefinch/lumberjack.v2"
+	"net/http"
+	"time"
 )
 
 // NewService creates a new service from the config struct
@@ -42,6 +44,9 @@ func NewService(ds kolide.Datastore, resultStore kolide.QueryResultStore,
 		osqueryResultLogWriter: resultWriter,
 		mailService:            mailService,
 		ssoSessionStore:        sso,
+		metaDataClient: http.Client{
+			Timeout: 5 * time.Second,
+		},
 	}
 	svc = validationMiddleware{svc, ds, sso}
 	return svc, nil
@@ -87,6 +92,7 @@ type service struct {
 
 	mailService     kolide.MailService
 	ssoSessionStore sso.SessionStore
+	metaDataClient  http.Client
 }
 
 func (s service) SendEmail(mail kolide.Email) error {

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -4,9 +4,11 @@ package service
 
 import (
 	"io"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/WatchBeam/clock"
 	kitlog "github.com/go-kit/kit/log"
@@ -15,8 +17,6 @@ import (
 	"github.com/kolide/fleet/server/logwriter"
 	"github.com/kolide/fleet/server/sso"
 	"gopkg.in/natefinch/lumberjack.v2"
-	"net/http"
-	"time"
 )
 
 // NewService creates a new service from the config struct
@@ -44,7 +44,7 @@ func NewService(ds kolide.Datastore, resultStore kolide.QueryResultStore,
 		osqueryResultLogWriter: resultWriter,
 		mailService:            mailService,
 		ssoSessionStore:        sso,
-		metaDataClient: http.Client{
+		metaDataClient: &http.Client{
 			Timeout: 5 * time.Second,
 		},
 	}
@@ -92,7 +92,7 @@ type service struct {
 
 	mailService     kolide.MailService
 	ssoSessionStore sso.SessionStore
-	metaDataClient  http.Client
+	metaDataClient  *http.Client
 }
 
 func (s service) SendEmail(mail kolide.Email) error {

--- a/server/service/service_sessions.go
+++ b/server/service/service_sessions.go
@@ -34,7 +34,7 @@ func (svc service) InitiateSSO(ctx context.Context, redirectURL string) (string,
 		return "", errors.Wrap(err, "InitiateSSO getting app config")
 	}
 
-	metadata, err := getMetadata(appConfig)
+	metadata, err := svc.getMetadata(appConfig)
 	if err != nil {
 		return "", errors.Wrap(err, "InitiateSSO getting metadata")
 	}
@@ -66,9 +66,9 @@ func (svc service) InitiateSSO(ctx context.Context, redirectURL string) (string,
 	return idpURL, nil
 }
 
-func getMetadata(config *kolide.AppConfig) (*sso.Metadata, error) {
+func (svc service) getMetadata(config *kolide.AppConfig) (*sso.Metadata, error) {
 	if config.MetadataURL != "" {
-		metadata, err := sso.GetMetadata(config.MetadataURL, 5*time.Second)
+		metadata, err := sso.GetMetadata(config.MetadataURL, svc.metaDataClient)
 		if err != nil {
 			return nil, err
 		}

--- a/server/sso/settings.go
+++ b/server/sso/settings.go
@@ -69,7 +69,7 @@ func ParseMetadata(metadata string) (*Metadata, error) {
 // IDP via a remote URL. metadataURL is the location where the metadata is located
 // and timeout defines how long to wait to get a response form the metadata
 // server.
-func GetMetadata(metadataURL string, client http.Client) (*Metadata, error) {
+func GetMetadata(metadataURL string, client *http.Client) (*Metadata, error) {
 	request, err := http.NewRequest(http.MethodGet, metadataURL, nil)
 	if err != nil {
 		return nil, err

--- a/server/sso/settings.go
+++ b/server/sso/settings.go
@@ -4,7 +4,6 @@ import (
 	"encoding/xml"
 	"io/ioutil"
 	"net/http"
-	"time"
 
 	"github.com/pkg/errors"
 
@@ -44,7 +43,6 @@ type SingleSignOnService struct {
 
 const (
 	PasswordProtectedTransport = "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"
-	PostBinding                = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
 	RedirectBinding            = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
 )
 
@@ -71,12 +69,11 @@ func ParseMetadata(metadata string) (*Metadata, error) {
 // IDP via a remote URL. metadataURL is the location where the metadata is located
 // and timeout defines how long to wait to get a response form the metadata
 // server.
-func GetMetadata(metadataURL string, timeout time.Duration) (*Metadata, error) {
+func GetMetadata(metadataURL string, client http.Client) (*Metadata, error) {
 	request, err := http.NewRequest(http.MethodGet, metadataURL, nil)
 	if err != nil {
 		return nil, err
 	}
-	client := http.Client{Timeout: timeout}
 	resp, err := client.Do(request)
 	if err != nil {
 		return nil, err

--- a/server/sso/settings_test.go
+++ b/server/sso/settings_test.go
@@ -62,7 +62,10 @@ func TestGetMetadata(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(metadata))
 	}))
-	settings, err := GetMetadata(ts.URL, 2*time.Second)
+	client := http.Client{
+		Timeout: 2 * time.Second,
+	}
+	settings, err := GetMetadata(ts.URL, client)
 	require.Nil(t, err)
 	assert.Equal(t, "http://www.okta.com/exka4zkf6dxm8pF220h7", settings.EntityID)
 	assert.Len(t, settings.IDPSSODescriptor.NameIDFormats, 2)

--- a/server/sso/settings_test.go
+++ b/server/sso/settings_test.go
@@ -62,7 +62,7 @@ func TestGetMetadata(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(metadata))
 	}))
-	client := http.Client{
+	client := &http.Client{
 		Timeout: 2 * time.Second,
 	}
 	settings, err := GetMetadata(ts.URL, client)


### PR DESCRIPTION
Closes #1587.  The `GetMetadata` method now reuses `http.Client`