### PR TITLE
Add flags to strip symbols during compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ ifndef MYSQL_PORT_3306_TCP_ADDR
 	MYSQL_PORT_3306_TCP_ADDR = 127.0.0.1
 endif
 
-KIT_VERSION = "\
+KIT_VERSION = "-w -s \
 	-X github.com/kolide/fleet/vendor/github.com/kolide/kit/version.appName=${APP_NAME} \
 	-X github.com/kolide/fleet/vendor/github.com/kolide/kit/version.version=${VERSION} \
 	-X github.com/kolide/fleet/vendor/github.com/kolide/kit/version.branch=${BRANCH} \


### PR DESCRIPTION
You get a nice 7M savings when the binary is stripped of extra symbols.

```
╰ ls -lah ./src/go/src/github.com/kolide/fleet/build/fleet
-rwxr-xr-x 1 tlambiris users 23M Nov 19 20:06 ./src/go/src/github.com/kolide/fleet/build/fleet
```

```
╰ ls -lah ./src/go/src/github.com/kolide/fleet/build/fleet
-rwxr-xr-x 1 tlambiris users 16M Nov 19 20:09 ./src/go/src/github.com/kolide/fleet/build/fleet
```