### PR TITLE
Write the raw status log to the writer

### DIFF
--- a/server/kolide/osquery.go
+++ b/server/kolide/osquery.go
@@ -18,7 +18,7 @@ type OsqueryService interface {
 	// feature.
 	GetDistributedQueries(ctx context.Context) (queries map[string]string, accelerate uint, err error)
 	SubmitDistributedQueryResults(ctx context.Context, results OsqueryDistributedQueryResults, statuses map[string]string) (err error)
-	SubmitStatusLogs(ctx context.Context, logs []OsqueryStatusLog) (err error)
+	SubmitStatusLogs(ctx context.Context, logs []json.RawMessage) (err error)
 	SubmitResultLogs(ctx context.Context, logs []json.RawMessage) (err error)
 }
 
@@ -70,14 +70,4 @@ type OsqueryConfig struct {
 	// FilePaths contains named collections of file paths used for
 	// FIM (File Integrity Monitoring)
 	FilePaths FIMSections `json:"file_paths,omitempty"`
-}
-
-// OsqueryStatusLog is the format of an osquery status log.
-type OsqueryStatusLog struct {
-	Severity    string            `json:"severity"`
-	Filename    string            `json:"filename"`
-	Line        string            `json:"line"`
-	Message     string            `json:"message"`
-	Version     string            `json:"version"`
-	Decorations map[string]string `json:"decorations"`
 }

--- a/server/launcher/launcher.go
+++ b/server/launcher/launcher.go
@@ -87,28 +87,10 @@ func (svc *launcherWrapper) PublishLogs(ctx context.Context, nodeKey string, log
 
 	switch logType {
 	case logger.LogTypeStatus:
-		var statuses []kolide.OsqueryStatusLog
+		var statuses []json.RawMessage
 		for _, log := range logs {
-			// StatusLog handles osquery logging messages
-			var statusLog = struct {
-				Severity string `json:"s"`
-				Filename string `json:"f"`
-				Line     string `json:"i"`
-				Message  string `json:"m"`
-			}{}
-
-			if err := json.Unmarshal([]byte(log), &statusLog); err != nil {
-				return "", "", false, errors.Wrap(err, "decode status log from launcher")
-			}
-
-			statuses = append(statuses, kolide.OsqueryStatusLog{
-				Severity: statusLog.Severity,
-				Filename: statusLog.Filename,
-				Line:     statusLog.Line,
-				Message:  statusLog.Message,
-			})
+			statuses = append(statuses, []byte(log))
 		}
-
 		err = svc.tls.SubmitStatusLogs(newCtx, statuses)
 		return "", "", false, errors.Wrap(err, "submit status logs from launcher")
 	case logger.LogTypeSnapshot, logger.LogTypeString:

--- a/server/launcher/launcher_test.go
+++ b/server/launcher/launcher_test.go
@@ -146,7 +146,7 @@ func newTLSService(t *testing.T) *mock.TLSService {
 			return
 		},
 
-		SubmitStatusLogsFunc: func(ctx context.Context, logs []kolide.OsqueryStatusLog) (err error) {
+		SubmitStatusLogsFunc: func(ctx context.Context, logs []json.RawMessage) (err error) {
 			return
 		},
 		SubmitResultLogsFunc: func(ctx context.Context, logs []json.RawMessage) (err error) {

--- a/server/mock/service_osquery.go
+++ b/server/mock/service_osquery.go
@@ -21,7 +21,7 @@ type GetDistributedQueriesFunc func(ctx context.Context) (queries map[string]str
 
 type SubmitDistributedQueryResultsFunc func(ctx context.Context, results kolide.OsqueryDistributedQueryResults, statuses map[string]string) (err error)
 
-type SubmitStatusLogsFunc func(ctx context.Context, logs []kolide.OsqueryStatusLog) (err error)
+type SubmitStatusLogsFunc func(ctx context.Context, logs []json.RawMessage) (err error)
 
 type SubmitResultLogsFunc func(ctx context.Context, logs []json.RawMessage) (err error)
 
@@ -73,7 +73,7 @@ func (s *TLSService) SubmitDistributedQueryResults(ctx context.Context, results 
 	return s.SubmitDistributedQueryResultsFunc(ctx, results, statuses)
 }
 
-func (s *TLSService) SubmitStatusLogs(ctx context.Context, logs []kolide.OsqueryStatusLog) (err error) {
+func (s *TLSService) SubmitStatusLogs(ctx context.Context, logs []json.RawMessage) (err error) {
 	s.SubmitStatusLogsFuncInvoked = true
 	return s.SubmitStatusLogsFunc(ctx, logs)
 }

--- a/server/service/endpoint_osquery.go
+++ b/server/service/endpoint_osquery.go
@@ -136,7 +136,7 @@ func makeSubmitLogsEndpoint(svc kolide.Service) endpoint.Endpoint {
 		var err error
 		switch req.LogType {
 		case "status":
-			var statuses []kolide.OsqueryStatusLog
+			var statuses []json.RawMessage
 			if err := json.Unmarshal(req.Data, &statuses); err != nil {
 				err = osqueryError{message: "unmarshalling status logs: " + err.Error()}
 				break

--- a/server/service/logging_osquery.go
+++ b/server/service/logging_osquery.go
@@ -105,7 +105,7 @@ func (mw loggingMiddleware) SubmitDistributedQueryResults(ctx context.Context, r
 	return err
 }
 
-func (mw loggingMiddleware) SubmitStatusLogs(ctx context.Context, logs []kolide.OsqueryStatusLog) error {
+func (mw loggingMiddleware) SubmitStatusLogs(ctx context.Context, logs []json.RawMessage) error {
 	var (
 		err error
 	)

--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -220,10 +220,9 @@ type flusher interface {
 	Flush() error
 }
 
-func (svc service) SubmitStatusLogs(ctx context.Context, logs []kolide.OsqueryStatusLog) error {
+func (svc service) SubmitStatusLogs(ctx context.Context, logs []json.RawMessage) error {
 	for _, log := range logs {
-		err := json.NewEncoder(svc.osqueryStatusLogWriter).Encode(log)
-		if err != nil {
+		if _, err := svc.osqueryStatusLogWriter.Write(append(log, '\n')); err != nil {
 			return osqueryError{message: "error writing status log: " + err.Error()}
 		}
 	}

--- a/server/service/service_osquery_test.go
+++ b/server/service/service_osquery_test.go
@@ -118,7 +118,7 @@ func TestSubmitStatusLogs(t *testing.T) {
 	}
 	logJSON := fmt.Sprintf("[%s]", strings.Join(logs, ","))
 
-	var status []kolide.OsqueryStatusLog
+	var status []json.RawMessage
 	err = json.Unmarshal([]byte(logJSON), &status)
 	require.Nil(t, err)
 


### PR DESCRIPTION
Instead of trying to decode and re-encode status logs, we now write them directly as they come in.
This change prevents future changes to the osquery status log file format (addition and deletion of fields ) from
affecting Fleet. A similar change was implemented in #1636 for result logs.

Closes #1664