### PR TITLE
Fix mysql connection pooling

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -123,8 +123,8 @@ func (man Manager) addConfigs() {
 		"MySQL TLS server name")
 	man.addConfigString("mysql.tls_config", "",
 		"MySQL TLS config value. Use skip-verify, true, false or custom key.")
-	man.addConfigInt("mysql.max_open_conns", 50, "MySQL maximum open connection handles.")
-	man.addConfigInt("mysql.max_idle_conns", 50, "MySQL maximum idle connection handles.")
+	man.addConfigInt("mysql.max_open_conns", 9, "MySQL maximum open connection handles.")
+	man.addConfigInt("mysql.max_idle_conns", 10, "MySQL maximum idle connection handles.")
 
 	// Redis
 	man.addConfigString("redis.address", "localhost:6379",

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -123,8 +123,8 @@ func (man Manager) addConfigs() {
 		"MySQL TLS server name")
 	man.addConfigString("mysql.tls_config", "",
 		"MySQL TLS config value. Use skip-verify, true, false or custom key.")
-	man.addConfigInt("mysql.max_open_conns", "50", "MySQL maximum open connection handles.")
-	man.addConfigInt("mysql.max_idle_conns", "50", "MySQL maximum idle connection handles.")
+	man.addConfigInt("mysql.max_open_conns", 50, "MySQL maximum open connection handles.")
+	man.addConfigInt("mysql.max_idle_conns", 50, "MySQL maximum idle connection handles.")
 
 	// Redis
 	man.addConfigString("redis.address", "localhost:6379",

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -25,8 +25,8 @@ type MysqlConfig struct {
 	TLSCA         string `yaml:"tls_ca"`
 	TLSServerName string `yaml:"tls_server_name"`
 	TLSConfig     string `yaml:"tls_config"` //tls=customValue in DSN
-	MaxOpenConns  string
-	MaxIdleConns  string
+	MaxOpenConns  int
+	MaxIdleConns  int
 }
 
 // RedisConfig defines configs related to Redis
@@ -123,8 +123,8 @@ func (man Manager) addConfigs() {
 		"MySQL TLS server name")
 	man.addConfigString("mysql.tls_config", "",
 		"MySQL TLS config value. Use skip-verify, true, false or custom key.")
-	man.addConfigString("mysql.max_open_conns", "50", "MySQL maximum open connection handles.")
-	man.addConfigString("mysql.max_idle_conns", "50", "MySQL maximum idle connection handles.")
+	man.addConfigInt("mysql.max_open_conns", "50", "MySQL maximum open connection handles.")
+	man.addConfigInt("mysql.max_idle_conns", "50", "MySQL maximum idle connection handles.")
 
 	// Redis
 	man.addConfigString("redis.address", "localhost:6379",
@@ -204,8 +204,8 @@ func (man Manager) LoadConfig() KolideConfig {
 			TLSCA:         man.getConfigString("mysql.tls_ca"),
 			TLSServerName: man.getConfigString("mysql.tls_server_name"),
 			TLSConfig:     man.getConfigString("mysql.tls_config"),
-			MaxOpenConns:  man.getConfigString("mysql.max_open_conns"),
-			MaxIdleConns:  man.getConfigString("mysql.max_idle_conns"),
+			MaxOpenConns:  man.getConfigInt("mysql.max_open_conns"),
+			MaxIdleConns:  man.getConfigInt("mysql.max_idle_conns"),
 		},
 		Redis: RedisConfig{
 			Address:  man.getConfigString("redis.address"),

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -25,8 +25,8 @@ type MysqlConfig struct {
 	TLSCA         string `yaml:"tls_ca"`
 	TLSServerName string `yaml:"tls_server_name"`
 	TLSConfig     string `yaml:"tls_config"` //tls=customValue in DSN
-	MaxOpenConns  int
-	MaxIdleConns  int
+	MaxOpenConns  int    `yaml:"max_open_conns"`
+	MaxIdleConns  int    `yaml:"max_idle_conns"`
 }
 
 // RedisConfig defines configs related to Redis
@@ -123,8 +123,8 @@ func (man Manager) addConfigs() {
 		"MySQL TLS server name")
 	man.addConfigString("mysql.tls_config", "",
 		"MySQL TLS config value. Use skip-verify, true, false or custom key.")
-	man.addConfigInt("mysql.max_open_conns", 9, "MySQL maximum open connection handles.")
-	man.addConfigInt("mysql.max_idle_conns", 10, "MySQL maximum idle connection handles.")
+	man.addConfigInt("mysql.max_open_conns", 50, "MySQL maximum open connection handles.")
+	man.addConfigInt("mysql.max_idle_conns", 50, "MySQL maximum idle connection handles.")
 
 	// Redis
 	man.addConfigString("redis.address", "localhost:6379",

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -25,6 +25,8 @@ type MysqlConfig struct {
 	TLSCA         string `yaml:"tls_ca"`
 	TLSServerName string `yaml:"tls_server_name"`
 	TLSConfig     string `yaml:"tls_config"` //tls=customValue in DSN
+	MaxOpenConns  string
+	MaxIdleConns  string
 }
 
 // RedisConfig defines configs related to Redis
@@ -121,6 +123,8 @@ func (man Manager) addConfigs() {
 		"MySQL TLS server name")
 	man.addConfigString("mysql.tls_config", "",
 		"MySQL TLS config value. Use skip-verify, true, false or custom key.")
+	man.addConfigString("mysql.max_open_conns", "50", "MySQL maximum open connection handles.")
+	man.addConfigString("mysql.max_idle_conns", "50", "MySQL maximum idle connection handles.")
 
 	// Redis
 	man.addConfigString("redis.address", "localhost:6379",

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -204,6 +204,8 @@ func (man Manager) LoadConfig() KolideConfig {
 			TLSCA:         man.getConfigString("mysql.tls_ca"),
 			TLSServerName: man.getConfigString("mysql.tls_server_name"),
 			TLSConfig:     man.getConfigString("mysql.tls_config"),
+			MaxOpenConns:  man.getConfigString("mysql.max_open_conns"),
+			MaxIdleConns:  man.getConfigString("mysql.max_idle_conns"),
 		},
 		Redis: RedisConfig{
 			Address:  man.getConfigString("redis.address"),

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -73,7 +73,7 @@ func New(config config.MysqlConfig, c clock.Clock, opts ...DBOption) (*Datastore
 		return nil, err
 	}
 
-	db.SetMaxIdleConns(config.MaxIdlenConns)
+	db.SetMaxIdleConns(config.MaxIdleConns)
 	db.SetMaxOpenConns(config.MaxOpenConns)
 
 	var dbError error

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -73,6 +73,9 @@ func New(config config.MysqlConfig, c clock.Clock, opts ...DBOption) (*Datastore
 		return nil, err
 	}
 
+	db.SetMaxIdleConns(n int)
+	db.SetMaxOpenConns(n int)	
+
 	var dbError error
 	for attempt := 0; attempt < options.maxAttempts; attempt++ {
 		dbError = db.Ping()

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	defaultSelectLimit = 100000
-	mysqlThreadCount   = 100
+	mySqlThreadCount   = 100
 )
 
 // Datastore is an implementation of kolide.Datastore interface backed by

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -21,7 +21,6 @@ import (
 
 const (
 	defaultSelectLimit = 100000
-	mySqlThreadCount   = 100
 )
 
 // Datastore is an implementation of kolide.Datastore interface backed by
@@ -74,8 +73,8 @@ func New(config config.MysqlConfig, c clock.Clock, opts ...DBOption) (*Datastore
 		return nil, err
 	}
 
-	db.SetMaxIdleConns(config.MaxOpenConns)
-	db.SetMaxOpenConns(config.MaxIdleConns)
+	db.SetMaxIdleConns(config.MaxIdlenConns)
+	db.SetMaxOpenConns(config.MaxOpenConns)
 
 	var dbError error
 	for attempt := 0; attempt < options.maxAttempts; attempt++ {

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -74,8 +74,8 @@ func New(config config.MysqlConfig, c clock.Clock, opts ...DBOption) (*Datastore
 		return nil, err
 	}
 
-	db.SetMaxIdleConns(mySqlThreadCount)
-	db.SetMaxOpenConns(mySqlThreadCount)
+	db.SetMaxIdleConns(mysql.max_open_conns)
+	db.SetMaxOpenConns(mysql.max_idle_conns)
 
 	var dbError error
 	for attempt := 0; attempt < options.maxAttempts; attempt++ {

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -74,8 +74,8 @@ func New(config config.MysqlConfig, c clock.Clock, opts ...DBOption) (*Datastore
 		return nil, err
 	}
 
-	db.SetMaxIdleConns(mysql.max_open_conns)
-	db.SetMaxOpenConns(mysql.max_idle_conns)
+	db.SetMaxIdleConns(config.MaxOpenConns)
+	db.SetMaxOpenConns(config.MaxIdleConns)
 
 	var dbError error
 	for attempt := 0; attempt < options.maxAttempts; attempt++ {

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	defaultSelectLimit = 100000
+	mysqlThreadCount   = 100
 )
 
 // Datastore is an implementation of kolide.Datastore interface backed by
@@ -73,8 +74,8 @@ func New(config config.MysqlConfig, c clock.Clock, opts ...DBOption) (*Datastore
 		return nil, err
 	}
 
-	db.SetMaxIdleConns(n int)
-	db.SetMaxOpenConns(n int)	
+	db.SetMaxIdleConns(mySqlThreadCount)
+	db.SetMaxOpenConns(mySqlThreadCount)
 
 	var dbError error
 	for attempt := 0; attempt < options.maxAttempts; attempt++ {


### PR DESCRIPTION
So I ran into an issue where 500+ hosts seems to make Kolide Fleet's web interface unusable (based on the quickstart Heroku script). 

Based on my own [lazy question](https://osquery.slack.com/archives/C1XCLA5DZ/p1513367450000172) and the help of folks like @marpaia & @groob I was pointed at issue https://github.com/kolide/fleet/issues/1513 indicating the need to cap open and idle MySQL connections. 

This is a start, but I'm working on it. Help or thoughts are welcome, but this is a current blocker for me. 

Closes #1513 