### PR TITLE
Fix missing removed and shard keys in query packs

### DIFF
--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -158,6 +158,12 @@ func (svc service) GetClientConfig(ctx context.Context) (map[string]interface{},
 				Interval: query.Interval,
 				Platform: query.Platform,
 				Version:  query.Version,
+				Removed:  query.Removed,
+				Shard:    query.Shard,
+			}
+
+			if query.Removed != nil {
+				queryContent.Removed = query.Removed
 			}
 
 			if query.Snapshot != nil && *query.Snapshot {

--- a/server/service/service_osquery_test.go
+++ b/server/service/service_osquery_test.go
@@ -382,14 +382,16 @@ func TestGetClientConfig(t *testing.T) {
 	}
 	ds.ListScheduledQueriesInPackFunc = func(pid uint, opt kolide.ListOptions) ([]*kolide.ScheduledQuery, error) {
 		tru := true
+		fals := false
+		fortytwo := uint(42)
 		switch pid {
 		case 1:
 			return []*kolide.ScheduledQuery{
-				{Name: "time", Query: "select * from time", Interval: 30},
+				{Name: "time", Query: "select * from time", Interval: 30, Removed: &fals},
 			}, nil
 		case 4:
 			return []*kolide.ScheduledQuery{
-				{Name: "foobar", Query: "select 3", Interval: 20},
+				{Name: "foobar", Query: "select 3", Interval: 20, Shard: &fortytwo},
 				{Name: "froobing", Query: "select 'guacamole'", Interval: 60, Snapshot: &tru},
 			}, nil
 		default:
@@ -437,13 +439,13 @@ func TestGetClientConfig(t *testing.T) {
 	assert.JSONEq(t, `{
 		"pack_by_explicit_host": {
 			"queries": {
-				"foobar":{"query":"select 3","interval":20},
+				"foobar":{"query":"select 3","interval":20,"shard":42},
 				"froobing":{"query":"select 'guacamole'","interval":60,"snapshot":true}
 			}
 		},
 		"pack_by_label": {
 			"queries":{
-				"time":{"query":"select * from time","interval":30}
+				"time":{"query":"select * from time","interval":30,"removed":false}
 			}
 		}
 	}`,


### PR DESCRIPTION
Include the appropriate values for `removed` and `shard` when generating config
to return to osqueryd.