### PR TITLE
Fix missing removed and shard keys in query packs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed bug in which shard and removed keys are dropped in query packs returned to osquery clients.
+
 ## Kolide Fleet 1.0.6 (Dec 4, 2017)
 
 * Added remote IP in the logs for all osqueryd/launcher requests. (#1653)

--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -168,6 +168,12 @@ func (svc service) GetClientConfig(ctx context.Context) (*kolide.OsqueryConfig, 
 				Interval: query.Interval,
 				Platform: query.Platform,
 				Version:  query.Version,
+				Removed:  query.Removed,
+				Shard:    query.Shard,
+			}
+
+			if query.Removed != nil {
+				queryContent.Removed = query.Removed
 			}
 
 			if query.Snapshot != nil && *query.Snapshot {


### PR DESCRIPTION
Include the appropriate values for removed and shard when generating config
to return to osqueryd.

Note: This was originally fixed and tested in the fleetctl branch (#1680), and
the fix is being cherry-picked into master without the test.