### PR TITLE
separate the docker build step from the docker push step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,8 @@ docker-build-release: .pre-fleet
 	GOOS=linux go build -i -o build/linux/${OUTPUT} -ldflags ${KIT_VERSION} ./cmd/fleet
 	docker build -t "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" .
 	docker tag "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" kolide/fleet:latest
+
+docker-push-release: docker-build-release
 	docker push "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
 	docker push kolide/fleet:latest
 


### PR DESCRIPTION
Allows users without write access to docker hub to still build the container.