### PR TITLE
WIP: Log Forwarding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,8 @@ deps:
 	go get -u \
 		github.com/jteeuwen/go-bindata/... \
 		github.com/golang/dep/cmd/dep \
-		github.com/groob/mockimpl
+		github.com/groob/mockimpl \
+		cloud.google.com/go/logging
 	dep ensure -vendor-only
 
 distclean:

--- a/server/logwriter/logwriter_file.go
+++ b/server/logwriter/logwriter_file.go
@@ -1,0 +1,151 @@
+package logwriter
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/kolide/fleet/server/config"
+
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+type fileWriter struct {
+	// No rotation.
+	file *os.File
+	buff *bufio.Writer
+
+	// Rotation.
+	jack *lumberjack.Logger
+
+	logger kitlog.Logger
+	mtx    sync.Mutex
+}
+
+func newFile(conf config.OsqueryLogFile, logger kitlog.Logger) (*fileWriter, error) {
+	// TODO(thorduri): Deal with compat if required.
+	if conf.Path == "" {
+		return nil, nil
+	}
+
+	fw := new(fileWriter)
+
+	if conf.EnableLogRotation {
+		logger = kitlog.With(logger, "type", "file", "rotation", true)
+
+		fw.jack = &lumberjack.Logger{
+			Filename:   conf.Path,
+			MaxSize:    500, // megabytes
+			MaxBackups: 3,
+			MaxAge:     28, //days
+		}
+
+		sig := make(chan os.Signal)
+		signal.Notify(sig, syscall.SIGHUP)
+
+		go func() {
+			for {
+				<-sig // Block on signal.
+				if err := fw.jack.Rotate(); err != nil {
+					logger.Log("err", err)
+				}
+			}
+		}()
+	} else {
+		logger = kitlog.With(logger, "type", "file", "rotation", false)
+
+		file, err := os.OpenFile(conf.Path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
+		if err != nil {
+			return nil, err
+		}
+		buff := bufio.NewWriter(file)
+
+		fw.file = file
+		fw.buff = buff
+	}
+
+	fw.logger = logger
+	return fw, nil
+}
+
+// Write bytes to file
+func (fw *fileWriter) Write(ctx context.Context, b []byte) error {
+	fw.mtx.Lock()
+	defer fw.mtx.Unlock()
+
+	if fw.jack != nil {
+		if _, err := fw.jack.Write(b); err != nil {
+			return errors.Wrapf(err, "filewriter: write failed")
+		}
+		return nil
+	}
+
+	if fw.buff == nil || fw.file == nil {
+		return errors.New("filewriter: can't write to closed file")
+	}
+	if _, statErr := os.Stat(fw.file.Name()); os.IsNotExist(statErr) {
+		f, err := os.OpenFile(fw.file.Name(), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
+		if err != nil {
+			return errors.Wrapf(err, "filewriter: can't create file %s", fw.file.Name())
+		}
+		fw.file = f
+		fw.buff = bufio.NewWriter(f)
+	}
+
+	if _, err := fw.buff.Write(b); err != nil {
+		return errors.Wrapf(err, "filewriter: write failed")
+	}
+	return nil
+}
+
+// Flush write all buffered bytes to log file
+func (fw *fileWriter) Flush(ctx context.Context) error {
+	fw.mtx.Lock()
+	defer fw.mtx.Unlock()
+
+	if fw.jack != nil {
+		return nil
+	}
+
+	if fw.buff == nil {
+		return errors.New("filewriter: can't write to a closed file")
+	}
+
+	if err := fw.buff.Flush(); err != nil {
+		return errors.Wrapf(err, "filewriter: flush failed")
+	}
+	return nil
+}
+
+// Close log file
+func (fw *fileWriter) Close(ctx context.Context) error {
+	fw.mtx.Lock()
+	defer fw.mtx.Unlock()
+
+	if fw.jack != nil {
+		if err := fw.jack.Close(); err != nil {
+			return errors.Wrapf(err, "filewriter: close failed")
+		}
+		return nil
+	}
+
+	if fw.buff != nil {
+		if err := fw.buff.Flush(); err != nil {
+			return errors.Wrapf(err, "filewriter: flush in close failed")
+		}
+		fw.buff = nil
+	}
+	if fw.file != nil {
+		if err := fw.file.Close(); err != nil {
+			return errors.Wrapf(err, "filewriter: close failed")
+		}
+		fw.file = nil
+	}
+
+	return nil
+}

--- a/server/logwriter/logwriter_stackdriver.go
+++ b/server/logwriter/logwriter_stackdriver.go
@@ -1,0 +1,78 @@
+package logwriter
+
+import (
+	"context"
+	"os"
+
+	"github.com/kolide/fleet/server/config"
+	hostctx "github.com/kolide/fleet/server/contexts/host"
+
+	"cloud.google.com/go/logging"
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+)
+
+type stackdriverWriter struct {
+	client      *logging.Client
+	stackdriver *logging.Logger
+	logger      kitlog.Logger
+}
+
+func newStackDriver(conf config.OsqueryLogStackDriver, logger kitlog.Logger) (*stackdriverWriter, error) {
+	if conf.ProjectID == "" && conf.ApplicationCredentials == "" {
+		return nil, nil
+	}
+
+	// XXX(thorduri): Banana.
+	if err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", conf.ApplicationCredentials); err != nil {
+		return nil, err
+	}
+
+	client, err := logging.NewClient(context.Background(), conf.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+
+	// XXX(thorduri): Status/Result annotations.
+	return &stackdriverWriter{
+		client:      client,
+		stackdriver: client.Logger("osquery"),
+		logger:      kitlog.With(logger, "type", "stackdriver"),
+	}, nil
+}
+
+func (sdw *stackdriverWriter) Write(ctx context.Context, b []byte) error {
+	host, ok := hostctx.FromContext(ctx)
+	if !ok {
+		// this can only happen if the host authz failed.
+		sdw.stackdriver.Log(logging.Entry{
+			Severity: logging.Alert,
+			Payload:  "logging osquery log without host ctx",
+		})
+		return nil
+	}
+
+	sdw.stackdriver.Log(logging.Entry{
+		Labels: map[string]string{
+			"osquery_host_hostname": host.HostName,
+			"osquery_host_uuid":     host.UUID,
+		},
+		Payload: b,
+	})
+
+	return nil
+}
+
+func (sdw *stackdriverWriter) Flush(ctx context.Context) error {
+	if err := sdw.stackdriver.Flush(); err != nil {
+		return errors.Wrap(err, "stackdriverwriter: flush failed")
+	}
+	return nil
+}
+
+func (sdw *stackdriverWriter) Close(ctx context.Context) error {
+	if err := sdw.client.Close(); err != nil {
+		return errors.Wrap(err, "stackdriverwriter: close failed")
+	}
+	return nil
+}

--- a/server/logwriter/logwriter_sumo.go
+++ b/server/logwriter/logwriter_sumo.go
@@ -1,0 +1,84 @@
+package logwriter
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/kolide/fleet/server/config"
+
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+)
+
+type sumoWriter struct {
+	collector string
+	client    *http.Client
+
+	buf    bytes.Buffer
+	logger kitlog.Logger
+	mtx    sync.Mutex
+}
+
+func newSumo(conf config.OsqueryLogSumo, logger kitlog.Logger) (*sumoWriter, error) {
+	if conf.Collector == "" {
+		return nil, nil
+	}
+
+	return &sumoWriter{
+		collector: conf.Collector,
+		logger:    kitlog.With(logger, "type", "sumo"),
+		client: &http.Client{
+			Timeout: 5 * time.Second,
+		},
+	}, nil
+}
+
+func (sw *sumoWriter) Write(ctx context.Context, b []byte) error {
+	sw.mtx.Lock()
+	defer sw.mtx.Unlock()
+
+	if _, err := sw.buf.Write(b); err != nil {
+		return errors.Wrapf(err, "sumowriter: write failed")
+	}
+	return nil
+}
+
+func (sw *sumoWriter) Flush(ctx context.Context) error {
+	var err error
+
+	sw.mtx.Lock()
+	defer sw.mtx.Unlock()
+
+	defer func(begin time.Time) {
+		_ = sw.logger.Log(
+			"method", "Flush",
+			"err", err,
+			"took", time.Since(begin),
+		)
+	}(time.Now())
+
+	// TODO(thorduri): Sumo Limitations.
+
+	body := bytes.NewReader(sw.buf.Bytes())
+	resp, err := sw.client.Post(sw.collector, "application/json", body)
+	if err != nil {
+		return errors.Wrap(err, "sumowriter: post failed")
+	} else if resp.StatusCode != http.StatusOK {
+		return errors.Errorf("sumowriter: post failed: %s", resp.Status)
+	}
+
+	sw.buf.Reset()
+
+	return nil
+}
+
+func (sw *sumoWriter) Close(ctx context.Context) error {
+	if err := sw.Flush(ctx); err != nil {
+		return errors.Wrap(err, "sumowriter: close failed")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Hi,

This PR starts adding support for optional log forwarding of osquery status/result logs,
and rather then present a bushwack of a PR with substantial refactoring I though it best
to present a working (I'm deploying this) example for discussion.

A rough laundry list of issues to resolve:

- How to configure and support forwarding endpoints

Adding a `type` and then interface implementations would probably suffice, e.g.
```
osquery:
  status_forwarding:
    type: http
    destination: ...
    authorization: ...
---
osquery:
  status_forwarding:
    type: sumo
    destination: ...
---
osquery:
  status_forwarding:
    type: stackdriver
    project_id: ...
````

This would neatly help with dealing the differences between the endpoints, i.e. maximum
body size limits, body layout, response status code for rate-limiting etc.

- Support more then one forwarder at a time (e.g. multiple result log forwarders)
Personally, I think this has limited use and would just add complexity.

- Refactoring

I'm currently investigating if the `logwriter` package can be repurposed to own the logs
and forwarding (being renamed into `logs` or similar), and build the interface implementations
there. 

One thing to note, is that currently logs are written to disk in the endpoint handler  for `/api/v1/osquery/log`, I'm unsure if this is the way to go forward when dealing with forwarders
as they might need to retry at a later time, so refactoring that to submit to a `logs` channel
and handling later might be required.