### PR TITLE
improved interface querying/populating for hosts

### DIFF
--- a/server/kolide/hosts.go
+++ b/server/kolide/hosts.go
@@ -5,6 +5,8 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"time"
+        "net"
+        "strings"
 )
 
 const (
@@ -132,6 +134,18 @@ func (h *Host) ResetPrimaryNetwork() bool {
 	// nics are in descending order of IO
 	// so we default to the most active nic
 	if len(h.NetworkInterfaces) > 0 {
+                // Check IPv4 address
+		for _, nic := range h.NetworkInterfaces {
+                        if strings.Index(nic.IPAddress, "127.") == 0 {
+                            continue
+                        }
+                        var isIpAddress = net.ParseIP(nic.IPAddress)
+                        if isIpAddress.To4() != nil {
+                            h.PrimaryNetworkInterfaceID = &nic.ID
+                            return true
+                        }
+		}
+                // return IPv6 or other nic in place of IPv4
 		h.PrimaryNetworkInterfaceID = &h.NetworkInterfaces[0].ID
 		return true
 	}

--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -277,9 +277,12 @@ var detailQueries = map[string]struct {
 	IngestFunc func(logger log.Logger, host *kolide.Host, rows []map[string]string) error
 }{
 	"network_interface": {
-		Query: `select * from interface_details id join interface_addresses ia
-                        on ia.interface = id.interface where broadcast != ""
-                        order by (ibytes + obytes) desc`,
+		Query: `select ia.interface, address, mask, broadcast, point_to_point,
+                               id.interface, mac, id.type, mtu, metric, ipackets, opackets,
+                               ibytes, obytes, ierrors, oerrors, idrops, odrops, last_change
+                        from interface_details id join interface_addresses ia
+                               on ia.interface = id.interface where length(mac) > 0
+                               order by (ibytes + obytes) desc`,
 		IngestFunc: func(logger log.Logger, host *kolide.Host, rows []map[string]string) (err error) {
 			if len(rows) == 0 {
 				logger.Log("component", "service", "method", "IngestFunc", "err",
@@ -295,14 +298,14 @@ var detailQueries = map[string]struct {
 				nic.IPAddress = row["address"]
 				nic.Broadcast = row["broadcast"]
 				if nic.IBytes, err = strconv.ParseInt(emptyToZero(row["ibytes"]), 10, 64); err != nil {
-					return err
+					nic.IBytes = -1
 				}
 				if nic.IErrors, err = strconv.ParseInt(emptyToZero(row["ierrors"]), 10, 64); err != nil {
-					return err
+					nic.IErrors = -1
 				}
 				nic.Interface = row["interface"]
 				if nic.IPackets, err = strconv.ParseInt(emptyToZero(row["ipackets"]), 10, 64); err != nil {
-					return err
+					nic.IPackets = -1
 				}
 				// Optional last_change
 				if lastChange, ok := row["last_change"]; ok {
@@ -318,13 +321,13 @@ var detailQueries = map[string]struct {
 					return err
 				}
 				if nic.OBytes, err = strconv.ParseInt(emptyToZero(row["obytes"]), 10, 64); err != nil {
-					return err
+					nic.OBytes = -1
 				}
 				if nic.OErrors, err = strconv.ParseInt(emptyToZero(row["oerrors"]), 10, 64); err != nil {
-					return err
+					nic.OErrors = -1
 				}
 				if nic.OPackets, err = strconv.ParseInt(emptyToZero(row["opackets"]), 10, 64); err != nil {
-					return err
+					nic.OPackets = -1
 				}
 				nic.PointToPoint = row["point_to_point"]
 				if nic.Type, err = strconv.Atoi(emptyToZero(row["type"])); err != nil {


### PR DESCRIPTION
pseudo-fix for #1676  - I cleaned up the query interface information query to make it specific, since Windows adds some additional fields.  I also removed localhost from candidates of likely primary network interfaces when identifying the best primary interface candidate.  Also, set -1 values when fields like Error, IBytes, OBytes, etc. are unparseable.  This probably should not fail the the entire process of populating NIC data. 

More investigation/development is needed to help support hosts with multiple interfaces.  For example, when dealing with NFS Linux servers, VM Servers, NIDS, etc.   