### PR TITLE
Remove default timestamp to fix strict error

### DIFF
--- a/server/datastore/mysql/migrations/tables/20161118212641_CreateTablePasswordResetRequests.go
+++ b/server/datastore/mysql/migrations/tables/20161118212641_CreateTablePasswordResetRequests.go
@@ -12,9 +12,9 @@ func Up_20161118212641(tx *sql.Tx) error {
 	_, err := tx.Exec(
 		"CREATE TABLE `password_reset_requests` (" +
 			"`id` int(10) unsigned NOT NULL AUTO_INCREMENT," +
+			"`expires_at` timestamp NOT NULL," +
 			"`created_at` timestamp DEFAULT CURRENT_TIMESTAMP," +
 			"`updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP," +
-			"`expires_at` timestamp NOT NULL DEFAULT '1970-01-01 00:00:01'," +
 			"`user_id` int(10) unsigned NOT NULL," +
 			"`token` varchar(1024) NOT NULL," +
 			"PRIMARY KEY (`id`)" +

--- a/server/datastore/mysql/password_reset.go
+++ b/server/datastore/mysql/password_reset.go
@@ -8,8 +8,8 @@ import (
 func (d *Datastore) NewPasswordResetRequest(req *kolide.PasswordResetRequest) (*kolide.PasswordResetRequest, error) {
 	sqlStatement := `
 		INSERT INTO password_reset_requests
-		( user_id, token)
-		VALUES (?,?)
+		( user_id, token, expires_at)
+		VALUES (?,?, NOW())
 	`
 	response, err := d.db.Exec(sqlStatement, req.UserID, req.Token)
 	if err != nil {


### PR DESCRIPTION
Running `fleet prepare db` on Ubuntu 16.04 with MySQL 5.7 fails for the reason @groob [pointed out here](https://github.com/kolide/fleet/issues/1644#issuecomment-347248450).  

The MySQL error is: `ERROR 1067 (42000): Invalid default value for 'expires_at'`

Removing the default on `expires_at` and using NOW() on INSERT resolves.