### PR TITLE
Remove extraneous text from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,4 +10,4 @@ When filing an issue, make sure to answer these five questions:
 
 Sensitive security-related issues should be reported to
 [security@kolide.co](mailto:security@kolide.co) before a public issue is made.
-vailable at http://contributor-covenant.org/version/1/4.
+


### PR DESCRIPTION
Last line of CONTRIBUTING.md appears to be accidentally copied in partially from the Code of Conduct doc. Removed for clarity.