### PR TITLE
Include RFC822 From header.

### DIFF
--- a/server/mail/mail.go
+++ b/server/mail/mail.go
@@ -54,7 +54,8 @@ func getMessageBody(e kolide.Email) ([]byte, error) {
 	mime := `MIME-version: 1.0;` + "\r\n"
 	content := `Content-Type: text/html; charset="UTF-8";` + "\r\n"
 	subject := "Subject: " + e.Subject + "\r\n"
-	msg := []byte(subject + mime + content + "\r\n" + string(body) + "\r\n")
+	from := "From: " + e.Config.SMTPSenderAddress + "\r\n"
+	msg := []byte(subject + from + mime + content + "\r\n" + string(body) + "\r\n")
 	return msg, nil
 }
 


### PR DESCRIPTION
The DMARC and DKIM email authentication systems both require the RFC822
`From` header to function.  Kolide currently only includes the configured
sender address as the SMTP Envelop From address (e.g., the MAIL FROM
command).  

This patch also includes the configured sender address in the
RFC822 email `From` header which should allow these emails to pass both
DKIM and DMARC authentication.