### PR TITLE
Update the CLI command scaffolding to match the docs

### DIFF
--- a/cmd/fleetctl/config.go
+++ b/cmd/fleetctl/config.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/urfave/cli"
+)
+
+func setupCommand() cli.Command {
+	var (
+		flAddress string
+	)
+	return cli.Command{
+		Name:      "setup",
+		Usage:     "Setup a Kolide Fleet instance",
+		UsageText: `fleetctl config login [options]`,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:        "address",
+				Value:       "",
+				Destination: &flAddress,
+				Usage:       "The address of the Kolide Fleet instance",
+			},
+		},
+		Action: func(cliCtx *cli.Context) error {
+			logger := log.NewLogfmtLogger(os.Stdout)
+			level.Info(logger).Log("msg", "setting up fleet")
+			return nil
+		},
+	}
+}
+
+func loginCommand() cli.Command {
+	var (
+		flAddress string
+	)
+	return cli.Command{
+		Name:      "login",
+		Usage:     "Login to Kolide Fleet",
+		UsageText: `fleetctl config login [options]`,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:        "address",
+				Value:       "",
+				Destination: &flAddress,
+				Usage:       "The address of the Kolide Fleet instance",
+			},
+		},
+		Action: func(cliCtx *cli.Context) error {
+			logger := log.NewLogfmtLogger(os.Stdout)
+			level.Info(logger).Log("msg", "logging in to fleet")
+			return nil
+		},
+	}
+}

--- a/cmd/fleetctl/fleetctl.go
+++ b/cmd/fleetctl/fleetctl.go
@@ -23,29 +23,27 @@ func main() {
 
 	app.Commands = []cli.Command{
 		cli.Command{
-			Name:        "create",
-			Usage:       "Create resources",
+			Name:        "query",
+			Usage:       "run a query across your fleet",
 			Subcommands: []cli.Command{},
 		},
 		cli.Command{
-			Name:        "get",
-			Usage:       "Get and list resources",
+			Name:        "apply",
+			Usage:       "apply a set of osquery configurations",
 			Subcommands: []cli.Command{},
 		},
 		cli.Command{
-			Name:        "put",
-			Usage:       "Create or update resources",
+			Name:        "edit",
+			Usage:       "edit your complete configuration in an ephemeral editor",
 			Subcommands: []cli.Command{},
 		},
 		cli.Command{
-			Name:        "delete",
-			Usage:       "Delete resources",
-			Subcommands: []cli.Command{},
-		},
-		cli.Command{
-			Name:        "ensure",
-			Usage:       "Ensures the state of resources",
-			Subcommands: []cli.Command{},
+			Name:  "config",
+			Usage: "modify how and which Fleet server to connect to",
+			Subcommands: []cli.Command{
+				loginCommand(),
+				setupCommand(),
+			},
 		},
 	}
 

--- a/server/kolide/packs.go
+++ b/server/kolide/packs.go
@@ -9,6 +9,7 @@ type PackStore interface {
 	// ApplyPackSpecs applies a list of PackSpecs to the datastore,
 	// creating and updating packs as necessary.
 	ApplyPackSpecs(specs []*PackSpec) error
+
 	// GetPackSpecs returns all of the stored PackSpecs.
 	GetPackSpecs() ([]*PackSpec, error)
 
@@ -20,6 +21,7 @@ type PackStore interface {
 
 	// ListPacks lists all packs in the datastore.
 	ListPacks(opt ListOptions) ([]*Pack, error)
+
 	// PackByName fetches pack if it exists, if the pack
 	// exists the bool return value is true
 	PackByName(name string, opts ...OptionalArg) (*Pack, bool, error)
@@ -44,6 +46,7 @@ type PackService interface {
 	// ApplyPackSpecs applies a list of PackSpecs to the datastore,
 	// creating and updating packs as necessary.
 	ApplyPackSpecs(ctx context.Context, specs []*PackSpec) error
+
 	// GetPackSpecs returns all of the stored PackSpecs.
 	GetPackSpecs(ctx context.Context) ([]*PackSpec, error)
 


### PR DESCRIPTION
This PR update the `fleetctl` CLI command scaffolding to match the current `fleetctl` documentation.