### PR TITLE
Delete spec entities by name instead of ID

### DIFF
--- a/server/datastore/datastore_labels_test.go
+++ b/server/datastore/datastore_labels_test.go
@@ -436,6 +436,7 @@ func testApplyLabelSpecsRoundtrip(t *testing.T, ds kolide.Datastore) {
 	}
 	err := ds.ApplyLabelSpecs(expectedSpecs)
 	require.Nil(t, err)
+
 	specs, err := ds.GetLabelSpecs()
 	require.Nil(t, err)
 	assert.Equal(t, expectedSpecs, specs)

--- a/server/datastore/datastore_packs_test.go
+++ b/server/datastore/datastore_packs_test.go
@@ -17,7 +17,7 @@ func testDeletePack(t *testing.T, ds kolide.Datastore) {
 	pack, err := ds.Pack(pack.ID)
 	require.Nil(t, err)
 
-	err = ds.DeletePack(pack.ID)
+	err = ds.DeletePack(pack.Name)
 	assert.Nil(t, err)
 
 	assert.NotEqual(t, uint(0), pack.ID)

--- a/server/datastore/datastore_queries_test.go
+++ b/server/datastore/datastore_queries_test.go
@@ -85,7 +85,7 @@ func testDeleteQuery(t *testing.T, ds kolide.Datastore) {
 	require.NotNil(t, query)
 	assert.NotEqual(t, query.ID, 0)
 
-	err = ds.DeleteQuery(query.ID)
+	err = ds.DeleteQuery(query.Name)
 	require.Nil(t, err)
 
 	assert.NotEqual(t, query.ID, 0)

--- a/server/datastore/inmem/inmem.go
+++ b/server/datastore/inmem/inmem.go
@@ -40,14 +40,9 @@ type Datastore struct {
 	appConfig                       *kolide.AppConfig
 	config                          *config.KolideConfig
 
-	// Embedded interfaces to avoid implementing new methods for (now
+	// Embedded interface to avoid implementing new methods for (now
 	// deprecated) inmem.
-	kolide.TargetStore
-	kolide.OsqueryOptionsStore
-	kolide.QueryStore
-	kolide.PackStore
-	kolide.ScheduledQueryStore
-	kolide.LabelStore
+	kolide.Datastore
 }
 
 func New(config config.KolideConfig) (*Datastore, error) {

--- a/server/datastore/inmem/labels.go
+++ b/server/datastore/inmem/labels.go
@@ -104,14 +104,6 @@ func (d *Datastore) RecordLabelQueryExecutions(host *kolide.Host, results map[ui
 	return nil
 }
 
-func (d *Datastore) DeleteLabel(lid uint) error {
-	d.mtx.Lock()
-	delete(d.labels, lid)
-	d.mtx.Unlock()
-
-	return nil
-}
-
 func (d *Datastore) Label(lid uint) (*kolide.Label, error) {
 	d.mtx.Lock()
 	label, ok := d.labels[lid]

--- a/server/datastore/inmem/packs.go
+++ b/server/datastore/inmem/packs.go
@@ -49,19 +49,6 @@ func (d *Datastore) SavePack(pack *kolide.Pack) error {
 	return nil
 }
 
-func (d *Datastore) DeletePack(pid uint) error {
-	d.mtx.Lock()
-	defer d.mtx.Unlock()
-
-	if _, ok := d.packs[pid]; !ok {
-		return notFound("Pack").WithID(pid)
-	}
-
-	delete(d.packs, pid)
-
-	return nil
-}
-
 func (d *Datastore) Pack(id uint) (*kolide.Pack, error) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()

--- a/server/datastore/inmem/queries.go
+++ b/server/datastore/inmem/queries.go
@@ -49,18 +49,6 @@ func (d *Datastore) SaveQuery(query *kolide.Query) error {
 	return nil
 }
 
-func (d *Datastore) DeleteQuery(qid uint) error {
-	d.mtx.Lock()
-	defer d.mtx.Unlock()
-
-	if _, ok := d.queries[qid]; !ok {
-		return notFound("Query").WithID(qid)
-	}
-
-	delete(d.queries, qid)
-	return nil
-}
-
 // DeleteQueries (soft) deletes the existing query objects with the provided
 // IDs. The number of deleted queries is returned along with any error.
 func (d *Datastore) DeleteQueries(ids []uint) (uint, error) {

--- a/server/datastore/mysql/delete.go
+++ b/server/datastore/mysql/delete.go
@@ -10,7 +10,7 @@ func (d *Datastore) deleteEntity(dbTable string, id uint) error {
 	deleteStmt := fmt.Sprintf(
 		`
 		UPDATE %s SET deleted_at = ?, deleted = TRUE
-			WHERE id = ? AND NOT deleted 
+			WHERE id = ? AND NOT deleted
 	`, dbTable)
 	result, err := d.db.Exec(deleteStmt, d.clock.Now(), id)
 	if err != nil {
@@ -19,6 +19,22 @@ func (d *Datastore) deleteEntity(dbTable string, id uint) error {
 	rows, _ := result.RowsAffected()
 	if rows != 1 {
 		return notFound(dbTable).WithID(id)
+	}
+	return nil
+}
+
+// deleteEntityByName hard deletes an entity with the given name from the given
+// DB table, returning a notFound error if appropriate.
+// Note: deleteEntity uses soft deletion, but we are moving off this pattern.
+func (d *Datastore) deleteEntityByName(dbTable string, name string) error {
+	deleteStmt := fmt.Sprintf("DELETE FROM %s WHERE name = ?", dbTable)
+	result, err := d.db.Exec(deleteStmt, name)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("delete %s", dbTable))
+	}
+	rows, _ := result.RowsAffected()
+	if rows != 1 {
+		return notFound(dbTable).WithName(name)
 	}
 	return nil
 }

--- a/server/datastore/mysql/errors.go
+++ b/server/datastore/mysql/errors.go
@@ -9,6 +9,7 @@ import (
 
 type notFoundError struct {
 	ID           uint
+	Name         string
 	Message      string
 	ResourceType string
 }
@@ -23,6 +24,9 @@ func (e *notFoundError) Error() string {
 	if e.ID != 0 {
 		return fmt.Sprintf("%s %d was not found in the datastore", e.ResourceType, e.ID)
 	}
+	if e.Name != "" {
+		return fmt.Sprintf("%s %s was not found in the datastore", e.ResourceType, e.Name)
+	}
 	if e.Message != "" {
 		return fmt.Sprintf("%s %s was not found in the datastore", e.ResourceType, e.Message)
 	}
@@ -31,6 +35,11 @@ func (e *notFoundError) Error() string {
 
 func (e *notFoundError) WithID(id uint) error {
 	e.ID = id
+	return e
+}
+
+func (e *notFoundError) WithName(name string) error {
+	e.Name = name
 	return e
 }
 

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -72,9 +72,9 @@ func (d *Datastore) GetLabelSpecs() ([]*kolide.LabelSpec, error) {
 	return specs, nil
 }
 
-// DeleteLabel soft deletes a kolide.Label
-func (d *Datastore) DeleteLabel(lid uint) error {
-	return d.deleteEntity("labels", lid)
+// DeleteLabel deletes a kolide.Label
+func (d *Datastore) DeleteLabel(name string) error {
+	return d.deleteEntityByName("labels", name)
 }
 
 // Label returns a kolide.Label identified by  lid if one exists

--- a/server/datastore/mysql/packs.go
+++ b/server/datastore/mysql/packs.go
@@ -192,8 +192,8 @@ func (d *Datastore) PackByName(name string, opts ...kolide.OptionalArg) (*kolide
 }
 
 // DeletePack soft deletes a kolide.Pack so that it won't show up in results
-func (d *Datastore) DeletePack(pid uint) error {
-	return d.deleteEntity("packs", pid)
+func (d *Datastore) DeletePack(name string) error {
+	return d.deleteEntityByName("packs", name)
 }
 
 // Pack fetch kolide.Pack with matching ID

--- a/server/datastore/mysql/queries.go
+++ b/server/datastore/mysql/queries.go
@@ -157,8 +157,8 @@ func (d *Datastore) SaveQuery(q *kolide.Query) error {
 }
 
 // DeleteQuery soft deletes Query identified by Query.ID
-func (d *Datastore) DeleteQuery(qid uint) error {
-	return d.deleteEntity("queries", qid)
+func (d *Datastore) DeleteQuery(name string) error {
+	return d.deleteEntityByName("queries", name)
 }
 
 // DeleteQueries (soft) deletes the existing query objects with the provided

--- a/server/kolide/labels.go
+++ b/server/kolide/labels.go
@@ -13,7 +13,7 @@ type LabelStore interface {
 	GetLabelSpecs() ([]*LabelSpec, error)
 
 	// Label methods
-	DeleteLabel(lid uint) error
+	DeleteLabel(name string) error
 	Label(lid uint) (*Label, error)
 	ListLabels(opt ListOptions) ([]*Label, error)
 
@@ -54,7 +54,8 @@ type LabelService interface {
 
 	ListLabels(ctx context.Context, opt ListOptions) (labels []*Label, err error)
 	GetLabel(ctx context.Context, id uint) (label *Label, err error)
-	DeleteLabel(ctx context.Context, id uint) (err error)
+
+	DeleteLabel(ctx context.Context, name string) (err error)
 
 	// HostIDsForLabel returns ids of hosts that belong to the label identified
 	// by lid

--- a/server/kolide/packs.go
+++ b/server/kolide/packs.go
@@ -14,7 +14,7 @@ type PackStore interface {
 	GetPackSpecs() ([]*PackSpec, error)
 
 	// DeletePack deletes a pack record from the datastore.
-	DeletePack(pid uint) error
+	DeletePack(name string) error
 
 	// Pack retrieves a pack from the datastore by ID.
 	Pack(pid uint) (*Pack, error)
@@ -57,7 +57,7 @@ type PackService interface {
 	GetPack(ctx context.Context, id uint) (pack *Pack, err error)
 
 	// DeletePack deletes a pack record from the datastore.
-	DeletePack(ctx context.Context, id uint) (err error)
+	DeletePack(ctx context.Context, name string) (err error)
 
 	// ListLabelsForPack lists all labels that are associated with a pack.
 	ListLabelsForPack(ctx context.Context, pid uint) (labels []*Label, err error)

--- a/server/kolide/queries.go
+++ b/server/kolide/queries.go
@@ -20,8 +20,8 @@ type QueryStore interface {
 	NewQuery(query *Query, opts ...OptionalArg) (*Query, error)
 	// SaveQuery saves changes to an existing query object.
 	SaveQuery(query *Query) error
-	// DeleteQuery (soft) deletes an existing query object.
-	DeleteQuery(qid uint) error
+	// DeleteQuery deletes an existing query object.
+	DeleteQuery(name string) error
 	// DeleteQueries (soft) deletes the existing query objects with the
 	// provided IDs. The number of deleted queries is returned along with
 	// any error.
@@ -51,7 +51,7 @@ type QueryService interface {
 	GetQuery(ctx context.Context, id uint) (*Query, error)
 	NewQuery(ctx context.Context, p QueryPayload) (*Query, error)
 	ModifyQuery(ctx context.Context, id uint, p QueryPayload) (*Query, error)
-	DeleteQuery(ctx context.Context, id uint) error
+	DeleteQuery(ctx context.Context, name string) error
 	// DeleteQueries (soft) deletes the existing query objects with the
 	// provided IDs. The number of deleted queries is returned along with
 	// any error.

--- a/server/mock/datastore_labels.go
+++ b/server/mock/datastore_labels.go
@@ -14,7 +14,7 @@ type ApplyLabelSpecsFunc func(specs []*kolide.LabelSpec) error
 
 type GetLabelSpecsFunc func() ([]*kolide.LabelSpec, error)
 
-type DeleteLabelFunc func(lid uint) error
+type DeleteLabelFunc func(name string) error
 
 type LabelFunc func(lid uint) (*kolide.Label, error)
 
@@ -77,9 +77,9 @@ func (s *LabelStore) GetLabelSpecs() ([]*kolide.LabelSpec, error) {
 	return s.GetLabelSpecsFunc()
 }
 
-func (s *LabelStore) DeleteLabel(lid uint) error {
+func (s *LabelStore) DeleteLabel(name string) error {
 	s.DeleteLabelFuncInvoked = true
-	return s.DeleteLabelFunc(lid)
+	return s.DeleteLabelFunc(name)
 }
 
 func (s *LabelStore) Label(lid uint) (*kolide.Label, error) {

--- a/server/mock/datastore_packs.go
+++ b/server/mock/datastore_packs.go
@@ -10,7 +10,7 @@ type ApplyPackSpecsFunc func(specs []*kolide.PackSpec) error
 
 type GetPackSpecsFunc func() ([]*kolide.PackSpec, error)
 
-type DeletePackFunc func(pid uint) error
+type DeletePackFunc func(name string) error
 
 type PackFunc func(pid uint) (*kolide.Pack, error)
 
@@ -68,9 +68,9 @@ func (s *PackStore) GetPackSpecs() ([]*kolide.PackSpec, error) {
 	return s.GetPackSpecsFunc()
 }
 
-func (s *PackStore) DeletePack(pid uint) error {
+func (s *PackStore) DeletePack(name string) error {
 	s.DeletePackFuncInvoked = true
-	return s.DeletePackFunc(pid)
+	return s.DeletePackFunc(name)
 }
 
 func (s *PackStore) Pack(pid uint) (*kolide.Pack, error) {

--- a/server/mock/datastore_queries.go
+++ b/server/mock/datastore_queries.go
@@ -12,7 +12,7 @@ type NewQueryFunc func(query *kolide.Query, opts ...kolide.OptionalArg) (*kolide
 
 type SaveQueryFunc func(query *kolide.Query) error
 
-type DeleteQueryFunc func(qid uint) error
+type DeleteQueryFunc func(name string) error
 
 type DeleteQueriesFunc func(ids []uint) (uint, error)
 
@@ -63,9 +63,9 @@ func (s *QueryStore) SaveQuery(query *kolide.Query) error {
 	return s.SaveQueryFunc(query)
 }
 
-func (s *QueryStore) DeleteQuery(qid uint) error {
+func (s *QueryStore) DeleteQuery(name string) error {
 	s.DeleteQueryFuncInvoked = true
-	return s.DeleteQueryFunc(qid)
+	return s.DeleteQueryFunc(name)
 }
 
 func (s *QueryStore) DeleteQueries(ids []uint) (uint, error) {

--- a/server/service/endpoint_labels.go
+++ b/server/service/endpoint_labels.go
@@ -107,7 +107,7 @@ func makeListLabelsEndpoint(svc kolide.Service) endpoint.Endpoint {
 ////////////////////////////////////////////////////////////////////////////////
 
 type deleteLabelRequest struct {
-	ID uint
+	Name string
 }
 
 type deleteLabelResponse struct {
@@ -119,7 +119,7 @@ func (r deleteLabelResponse) error() error { return r.Err }
 func makeDeleteLabelEndpoint(svc kolide.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(deleteLabelRequest)
-		err := svc.DeleteLabel(ctx, req.ID)
+		err := svc.DeleteLabel(ctx, req.Name)
 		if err != nil {
 			return deleteLabelResponse{Err: err}, nil
 		}

--- a/server/service/endpoint_packs.go
+++ b/server/service/endpoint_packs.go
@@ -130,7 +130,7 @@ func makeListPacksEndpoint(svc kolide.Service) endpoint.Endpoint {
 ////////////////////////////////////////////////////////////////////////////////
 
 type deletePackRequest struct {
-	ID uint
+	Name string
 }
 
 type deletePackResponse struct {
@@ -142,7 +142,7 @@ func (r deletePackResponse) error() error { return r.Err }
 func makeDeletePackEndpoint(svc kolide.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(deletePackRequest)
-		err := svc.DeletePack(ctx, req.ID)
+		err := svc.DeletePack(ctx, req.Name)
 		if err != nil {
 			return deletePackResponse{Err: err}, nil
 		}

--- a/server/service/endpoint_queries.go
+++ b/server/service/endpoint_queries.go
@@ -121,7 +121,7 @@ func makeModifyQueryEndpoint(svc kolide.Service) endpoint.Endpoint {
 ////////////////////////////////////////////////////////////////////////////////
 
 type deleteQueryRequest struct {
-	ID uint
+	Name string
 }
 
 type deleteQueryResponse struct {
@@ -133,7 +133,7 @@ func (r deleteQueryResponse) error() error { return r.Err }
 func makeDeleteQueryEndpoint(svc kolide.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(deleteQueryRequest)
-		err := svc.DeleteQuery(ctx, req.ID)
+		err := svc.DeleteQuery(ctx, req.Name)
 		if err != nil {
 			return deleteQueryResponse{Err: err}, nil
 		}

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -386,7 +386,7 @@ func attachKolideAPIRoutes(r *mux.Router, h *kolideHandlers) {
 	r.Handle("/api/v1/kolide/queries", h.ListQueries).Methods("GET").Name("list_queries")
 	r.Handle("/api/v1/kolide/queries", h.CreateQuery).Methods("POST").Name("create_query")
 	r.Handle("/api/v1/kolide/queries/{id}", h.ModifyQuery).Methods("PATCH").Name("modify_query")
-	r.Handle("/api/v1/kolide/queries/{id}", h.DeleteQuery).Methods("DELETE").Name("delete_query")
+	r.Handle("/api/v1/kolide/queries/{name}", h.DeleteQuery).Methods("DELETE").Name("delete_query")
 	r.Handle("/api/v1/kolide/queries/delete", h.DeleteQueries).Methods("POST").Name("delete_queries")
 	r.Handle("/api/v1/kolide/queries/spec", h.ApplyQuerySpecs).Methods("POST").Name("apply_query_specs")
 	r.Handle("/api/v1/kolide/queries/spec", h.GetQuerySpecs).Methods("GET").Name("get_query_specs")
@@ -394,7 +394,7 @@ func attachKolideAPIRoutes(r *mux.Router, h *kolideHandlers) {
 
 	r.Handle("/api/v1/kolide/packs/{id}", h.GetPack).Methods("GET").Name("get_pack")
 	r.Handle("/api/v1/kolide/packs", h.ListPacks).Methods("GET").Name("list_packs")
-	r.Handle("/api/v1/kolide/packs/{id}", h.DeletePack).Methods("DELETE").Name("delete_pack")
+	r.Handle("/api/v1/kolide/packs/{name}", h.DeletePack).Methods("DELETE").Name("delete_pack")
 	r.Handle("/api/v1/kolide/packs/{id}/scheduled", h.GetScheduledQueriesInPack).Methods("GET").Name("get_scheduled_queries_in_pack")
 	r.Handle("/api/v1/kolide/packs/spec", h.ApplyPackSpecs).Methods("POST").Name("apply_pack_specs")
 	r.Handle("/api/v1/kolide/packs/spec", h.GetPackSpecs).Methods("GET").Name("get_pack_specs")

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -401,7 +401,7 @@ func attachKolideAPIRoutes(r *mux.Router, h *kolideHandlers) {
 
 	r.Handle("/api/v1/kolide/labels/{id}", h.GetLabel).Methods("GET").Name("get_label")
 	r.Handle("/api/v1/kolide/labels", h.ListLabels).Methods("GET").Name("list_labels")
-	r.Handle("/api/v1/kolide/labels/{id}", h.DeleteLabel).Methods("DELETE").Name("delete_label")
+	r.Handle("/api/v1/kolide/labels/{name}", h.DeleteLabel).Methods("DELETE").Name("delete_label")
 	r.Handle("/api/v1/kolide/labels/spec", h.ApplyLabelSpecs).Methods("POST").Name("apply_label_specs")
 	r.Handle("/api/v1/kolide/labels/spec", h.GetLabelSpecs).Methods("GET").Name("get_label_specs")
 

--- a/server/service/logging_labels.go
+++ b/server/service/logging_labels.go
@@ -43,7 +43,7 @@ func (mw loggingMiddleware) GetLabel(ctx context.Context, id uint) (*kolide.Labe
 	return label, err
 }
 
-func (mw loggingMiddleware) DeleteLabel(ctx context.Context, id uint) error {
+func (mw loggingMiddleware) DeleteLabel(ctx context.Context, name string) error {
 	var (
 		err error
 	)
@@ -56,6 +56,6 @@ func (mw loggingMiddleware) DeleteLabel(ctx context.Context, id uint) error {
 		)
 	}(time.Now())
 
-	err = mw.Service.DeleteLabel(ctx, id)
+	err = mw.Service.DeleteLabel(ctx, name)
 	return err
 }

--- a/server/service/logging_packs.go
+++ b/server/service/logging_packs.go
@@ -43,7 +43,7 @@ func (mw loggingMiddleware) GetPack(ctx context.Context, id uint) (*kolide.Pack,
 	return pack, err
 }
 
-func (mw loggingMiddleware) DeletePack(ctx context.Context, id uint) error {
+func (mw loggingMiddleware) DeletePack(ctx context.Context, name string) error {
 	var (
 		err error
 	)
@@ -56,7 +56,7 @@ func (mw loggingMiddleware) DeletePack(ctx context.Context, id uint) error {
 		)
 	}(time.Now())
 
-	err = mw.Service.DeletePack(ctx, id)
+	err = mw.Service.DeletePack(ctx, name)
 	return err
 }
 

--- a/server/service/service_labels.go
+++ b/server/service/service_labels.go
@@ -22,8 +22,8 @@ func (svc service) GetLabel(ctx context.Context, id uint) (*kolide.Label, error)
 	return svc.ds.Label(id)
 }
 
-func (svc service) DeleteLabel(ctx context.Context, id uint) error {
-	return svc.ds.DeleteLabel(id)
+func (svc service) DeleteLabel(ctx context.Context, name string) error {
+	return svc.ds.DeleteLabel(name)
 }
 
 func (svc service) HostIDsForLabel(lid uint) ([]uint, error) {

--- a/server/service/service_labels_test.go
+++ b/server/service/service_labels_test.go
@@ -31,28 +31,3 @@ func TestGetLabel(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, label.ID, labelVerify.ID)
 }
-
-func TestDeleteLabel(t *testing.T) {
-	ds, err := inmem.New(config.TestConfig())
-	assert.Nil(t, err)
-
-	svc, err := newTestService(ds, nil)
-	assert.Nil(t, err)
-
-	ctx := context.Background()
-
-	label := &kolide.Label{
-		Name:  "foo",
-		Query: "select * from foo;",
-	}
-	label, err = ds.NewLabel(label)
-	assert.Nil(t, err)
-	assert.NotZero(t, label.ID)
-
-	err = svc.DeleteLabel(ctx, label.ID)
-	assert.Nil(t, err)
-
-	labels, err := ds.ListLabels(kolide.ListOptions{})
-	assert.Nil(t, err)
-	assert.Len(t, labels, 0)
-}

--- a/server/service/service_packs.go
+++ b/server/service/service_packs.go
@@ -22,8 +22,8 @@ func (svc service) GetPack(ctx context.Context, id uint) (*kolide.Pack, error) {
 	return svc.ds.Pack(id)
 }
 
-func (svc service) DeletePack(ctx context.Context, id uint) error {
-	return svc.ds.DeletePack(id)
+func (svc service) DeletePack(ctx context.Context, name string) error {
+	return svc.ds.DeletePack(name)
 }
 
 func (svc service) ListLabelsForPack(ctx context.Context, pid uint) ([]*kolide.Label, error) {

--- a/server/service/service_packs_test.go
+++ b/server/service/service_packs_test.go
@@ -54,27 +54,3 @@ func TestGetPack(t *testing.T) {
 
 	assert.Equal(t, pack.ID, packVerify.ID)
 }
-
-func TestDeletePack(t *testing.T) {
-	ds, err := inmem.New(config.TestConfig())
-	assert.Nil(t, err)
-
-	svc, err := newTestService(ds, nil)
-	assert.Nil(t, err)
-
-	ctx := context.Background()
-
-	pack := &kolide.Pack{
-		Name: "foo",
-	}
-	_, err = ds.NewPack(pack)
-	assert.Nil(t, err)
-	assert.NotZero(t, pack.ID)
-
-	err = svc.DeletePack(ctx, pack.ID)
-	assert.Nil(t, err)
-
-	queries, err := ds.ListPacks(kolide.ListOptions{})
-	assert.Nil(t, err)
-	assert.Len(t, queries, 0)
-}

--- a/server/service/service_queries.go
+++ b/server/service/service_queries.go
@@ -115,8 +115,8 @@ func (svc service) ModifyQuery(ctx context.Context, id uint, p kolide.QueryPaylo
 	return query, nil
 }
 
-func (svc service) DeleteQuery(ctx context.Context, id uint) error {
-	return svc.ds.DeleteQuery(id)
+func (svc service) DeleteQuery(ctx context.Context, name string) error {
+	return svc.ds.DeleteQuery(name)
 }
 
 func (svc service) DeleteQueries(ctx context.Context, ids []uint) (uint, error) {

--- a/server/service/service_queries_test.go
+++ b/server/service/service_queries_test.go
@@ -117,28 +117,3 @@ func TestModifyQuery(t *testing.T) {
 	assert.Equal(t, query.ID, queryVerify.ID)
 	assert.Equal(t, "bar", queryVerify.Name)
 }
-
-func TestDeleteQuery(t *testing.T) {
-	ds, err := inmem.New(config.TestConfig())
-	assert.Nil(t, err)
-
-	svc, err := newTestService(ds, nil)
-	assert.Nil(t, err)
-
-	ctx := context.Background()
-
-	query := &kolide.Query{
-		Name:  "foo",
-		Query: "select * from time;",
-	}
-	query, err = ds.NewQuery(query)
-	assert.Nil(t, err)
-	assert.NotZero(t, query.ID)
-
-	err = svc.DeleteQuery(ctx, query.ID)
-	assert.Nil(t, err)
-
-	queries, err := ds.ListQueries(kolide.ListOptions{})
-	assert.Nil(t, err)
-	assert.Len(t, queries, 0)
-}

--- a/server/service/transport.go
+++ b/server/service/transport.go
@@ -68,6 +68,15 @@ func idFromRequest(r *http.Request, name string) (uint, error) {
 	return uint(uid), nil
 }
 
+func nameFromRequest(r *http.Request, varName string) (string, error) {
+	vars := mux.Vars(r)
+	name, ok := vars[varName]
+	if !ok {
+		return "", errBadRoute
+	}
+	return name, nil
+}
+
 // default number of items to include per page
 const defaultPerPage = 20
 

--- a/server/service/transport_labels.go
+++ b/server/service/transport_labels.go
@@ -7,12 +7,12 @@ import (
 )
 
 func decodeDeleteLabelRequest(ctx context.Context, r *http.Request) (interface{}, error) {
-	id, err := idFromRequest(r, "id")
+	name, err := nameFromRequest(r, "name")
 	if err != nil {
 		return nil, err
 	}
 	var req deleteLabelRequest
-	req.ID = id
+	req.Name = name
 	return req, nil
 }
 

--- a/server/service/transport_labels_test.go
+++ b/server/service/transport_labels_test.go
@@ -12,17 +12,17 @@ import (
 
 func TestDecodeDeleteLabelRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/labels/{id}", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/kolide/labels/{name}", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeDeleteLabelRequest(context.Background(), request)
 		assert.Nil(t, err)
 
 		params := r.(deleteLabelRequest)
-		assert.Equal(t, uint(1), params.ID)
+		assert.Equal(t, "foo", params.Name)
 	}).Methods("DELETE")
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("DELETE", "/api/v1/kolide/labels/1", nil),
+		httptest.NewRequest("DELETE", "/api/v1/kolide/labels/foo", nil),
 	)
 }
 

--- a/server/service/transport_packs.go
+++ b/server/service/transport_packs.go
@@ -7,12 +7,12 @@ import (
 )
 
 func decodeDeletePackRequest(ctx context.Context, r *http.Request) (interface{}, error) {
-	id, err := idFromRequest(r, "id")
+	name, err := nameFromRequest(r, "name")
 	if err != nil {
 		return nil, err
 	}
 	var req deletePackRequest
-	req.ID = id
+	req.Name = name
 	return req, nil
 }
 

--- a/server/service/transport_packs_test.go
+++ b/server/service/transport_packs_test.go
@@ -12,17 +12,17 @@ import (
 
 func TestDecodeDeletePackRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/packs/{id}", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/kolide/packs/{name}", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeDeletePackRequest(context.Background(), request)
 		assert.Nil(t, err)
 
 		params := r.(deletePackRequest)
-		assert.Equal(t, uint(1), params.ID)
+		assert.Equal(t, "packaday", params.Name)
 	}).Methods("DELETE")
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("DELETE", "/api/v1/kolide/packs/1", nil),
+		httptest.NewRequest("DELETE", "/api/v1/kolide/packs/packaday", nil),
 	)
 }
 

--- a/server/service/transport_queries.go
+++ b/server/service/transport_queries.go
@@ -28,12 +28,12 @@ func decodeModifyQueryRequest(ctx context.Context, r *http.Request) (interface{}
 }
 
 func decodeDeleteQueryRequest(ctx context.Context, r *http.Request) (interface{}, error) {
-	id, err := idFromRequest(r, "id")
+	name, err := nameFromRequest(r, "name")
 	if err != nil {
 		return nil, err
 	}
 	var req deleteQueryRequest
-	req.ID = id
+	req.Name = name
 	return req, nil
 }
 

--- a/server/service/transport_queries_test.go
+++ b/server/service/transport_queries_test.go
@@ -58,17 +58,17 @@ func TestDecodeModifyQueryRequest(t *testing.T) {
 
 func TestDecodeDeleteQueryRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/queries/{id}", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/kolide/queries/{name}", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeDeleteQueryRequest(context.Background(), request)
 		assert.Nil(t, err)
 
 		params := r.(deleteQueryRequest)
-		assert.Equal(t, uint(1), params.ID)
+		assert.Equal(t, "qwerty", params.Name)
 	}).Methods("DELETE")
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("DELETE", "/api/v1/kolide/queries/1", nil),
+		httptest.NewRequest("DELETE", "/api/v1/kolide/queries/qwerty", nil),
 	)
 }
 


### PR DESCRIPTION
With the UI, deleting by ID made sense. With `fleetctl`, we now want to delete
by name. Transition only the methods used for spec related entities, as others
will be removed soon.