### PR TITLE
Fixes in query, pack and label clients

### DIFF
--- a/server/service/client_labels.go
+++ b/server/service/client_labels.go
@@ -13,7 +13,7 @@ import (
 // Fleet instance.
 func (c *Client) ApplyLabelSpecs(specs []*kolide.LabelSpec) error {
 	req := applyLabelSpecsRequest{Specs: specs}
-	response, err := c.Do("POST", "/api/v1/kolide/spec/labels", req)
+	response, err := c.AuthenticatedDo("POST", "/api/v1/kolide/spec/labels", req)
 	if err != nil {
 		return errors.Wrap(err, "POST /api/v1/kolide/spec/labels")
 	}
@@ -37,9 +37,8 @@ func (c *Client) ApplyLabelSpecs(specs []*kolide.LabelSpec) error {
 }
 
 // GetLabelSpecs retrieves the list of all Labels.
-func (c *Client) GetLabelSpecs(specs []*kolide.LabelSpec) ([]*kolide.LabelSpec, error) {
-	req := applyLabelSpecsRequest{Specs: specs}
-	response, err := c.Do("GET", "/api/v1/kolide/spec/labels", req)
+func (c *Client) GetLabelSpecs() ([]*kolide.LabelSpec, error) {
+	response, err := c.AuthenticatedDo("GET", "/api/v1/kolide/spec/labels", nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "GET /api/v1/kolide/spec/labels")
 	}
@@ -65,7 +64,7 @@ func (c *Client) GetLabelSpecs(specs []*kolide.LabelSpec) ([]*kolide.LabelSpec, 
 // DeleteLabel deletes the label with the matching name.
 func (c *Client) DeleteLabel(name string) error {
 	verb, path := "DELETE", "/api/v1/kolide/labels/"+url.QueryEscape(name)
-	response, err := c.Do(verb, path, nil)
+	response, err := c.AuthenticatedDo(verb, path, nil)
 	if err != nil {
 		return errors.Wrapf(err, "%s %s", verb, path)
 	}

--- a/server/service/client_packs.go
+++ b/server/service/client_packs.go
@@ -13,7 +13,7 @@ import (
 // Fleet instance.
 func (c *Client) ApplyPackSpecs(specs []*kolide.PackSpec) error {
 	req := applyPackSpecsRequest{Specs: specs}
-	response, err := c.Do("POST", "/api/v1/kolide/spec/packs", req)
+	response, err := c.AuthenticatedDo("POST", "/api/v1/kolide/spec/packs", req)
 	if err != nil {
 		return errors.Wrap(err, "POST /api/v1/kolide/spec/packs")
 	}
@@ -37,9 +37,8 @@ func (c *Client) ApplyPackSpecs(specs []*kolide.PackSpec) error {
 }
 
 // GetPackSpecs retrieves the list of all Packs.
-func (c *Client) GetPackSpecs(specs []*kolide.PackSpec) ([]*kolide.PackSpec, error) {
-	req := applyPackSpecsRequest{Specs: specs}
-	response, err := c.Do("GET", "/api/v1/kolide/spec/packs", req)
+func (c *Client) GetPackSpecs() ([]*kolide.PackSpec, error) {
+	response, err := c.AuthenticatedDo("GET", "/api/v1/kolide/spec/packs", nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "GET /api/v1/kolide/spec/packs")
 	}
@@ -65,7 +64,7 @@ func (c *Client) GetPackSpecs(specs []*kolide.PackSpec) ([]*kolide.PackSpec, err
 // DeletePack deletes the pack with the matching name.
 func (c *Client) DeletePack(name string) error {
 	verb, path := "DELETE", "/api/v1/kolide/packs/"+url.QueryEscape(name)
-	response, err := c.Do(verb, path, nil)
+	response, err := c.AuthenticatedDo(verb, path, nil)
 	if err != nil {
 		return errors.Wrapf(err, "%s %s", verb, path)
 	}

--- a/server/service/client_queries.go
+++ b/server/service/client_queries.go
@@ -13,7 +13,7 @@ import (
 // Fleet instance.
 func (c *Client) ApplyQuerySpecs(specs []*kolide.QuerySpec) error {
 	req := applyQuerySpecsRequest{Specs: specs}
-	response, err := c.Do("POST", "/api/v1/kolide/spec/queries", req)
+	response, err := c.AuthenticatedDo("POST", "/api/v1/kolide/spec/queries", req)
 	if err != nil {
 		return errors.Wrap(err, "POST /api/v1/kolide/spec/queries")
 	}
@@ -37,9 +37,8 @@ func (c *Client) ApplyQuerySpecs(specs []*kolide.QuerySpec) error {
 }
 
 // GetQuerySpecs retrieves the list of all Queries.
-func (c *Client) GetQuerySpecs(specs []*kolide.QuerySpec) ([]*kolide.QuerySpec, error) {
-	req := applyQuerySpecsRequest{Specs: specs}
-	response, err := c.Do("GET", "/api/v1/kolide/spec/queries", req)
+func (c *Client) GetQuerySpecs() ([]*kolide.QuerySpec, error) {
+	response, err := c.AuthenticatedDo("GET", "/api/v1/kolide/spec/queries", nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "GET /api/v1/kolide/spec/queries")
 	}
@@ -65,7 +64,7 @@ func (c *Client) GetQuerySpecs(specs []*kolide.QuerySpec) ([]*kolide.QuerySpec, 
 // DeleteQuery deletes the query with the matching name.
 func (c *Client) DeleteQuery(name string) error {
 	verb, path := "DELETE", "/api/v1/kolide/queries/"+url.QueryEscape(name)
-	response, err := c.Do(verb, path, nil)
+	response, err := c.AuthenticatedDo(verb, path, nil)
 	if err != nil {
 		return errors.Wrapf(err, "%s %s", verb, path)
 	}


### PR DESCRIPTION
- Use authenticated requests
- Don't take a parameter for the Get*Specs methods