### PR TITLE
Add fleetctl get label, pack, query for individual items by name

### DIFF
--- a/cmd/fleetctl/apply.go
+++ b/cmd/fleetctl/apply.go
@@ -134,21 +134,21 @@ func applyCommand() cli.Command {
 			}
 
 			if len(specs.Queries) > 0 {
-				if err := fleet.ApplyQuerySpecs(specs.Queries); err != nil {
+				if err := fleet.ApplyQueries(specs.Queries); err != nil {
 					return errors.Wrap(err, "applying queries")
 				}
 				fmt.Printf("[+] applied %d queries\n", len(specs.Queries))
 			}
 
 			if len(specs.Labels) > 0 {
-				if err := fleet.ApplyLabelSpecs(specs.Labels); err != nil {
+				if err := fleet.ApplyLabels(specs.Labels); err != nil {
 					return errors.Wrap(err, "applying labels")
 				}
 				fmt.Printf("[+] applied %d labels\n", len(specs.Labels))
 			}
 
 			if len(specs.Packs) > 0 {
-				if err := fleet.ApplyPackSpecs(specs.Packs); err != nil {
+				if err := fleet.ApplyPacks(specs.Packs); err != nil {
 					return errors.Wrap(err, "applying packs")
 				}
 				fmt.Printf("[+] applied %d packs\n", len(specs.Packs))

--- a/cmd/fleetctl/get.go
+++ b/cmd/fleetctl/get.go
@@ -4,10 +4,18 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/ghodss/yaml"
+	"github.com/kolide/fleet/server/kolide"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
+
+type specGeneric struct {
+	Kind    string      `json:"kind"`
+	Version string      `json:"apiVersion"`
+	Spec    interface{} `json:"spec"`
+}
 
 func defaultTable() *tablewriter.Table {
 	table := tablewriter.NewWriter(os.Stdout)
@@ -34,7 +42,7 @@ func getQueriesCommand() cli.Command {
 
 			// if name wasn't provided, list all queries
 			if name == "" {
-				queries, err := fleet.GetQuerySpecs()
+				queries, err := fleet.GetQueries()
 				if err != nil {
 					return errors.Wrap(err, "could not list queries")
 				}
@@ -61,7 +69,23 @@ func getQueriesCommand() cli.Command {
 
 				return nil
 			} else {
-				fmt.Println("[+] Getting information on a specific query is not currently supported")
+				query, err := fleet.GetQuery(name)
+				if err != nil {
+					return err
+				}
+
+				spec := specGeneric{
+					Kind:    "query",
+					Version: kolide.ApiVersion,
+					Spec:    query,
+				}
+
+				b, err := yaml.Marshal(spec)
+				if err != nil {
+					return err
+				}
+
+				fmt.Printf(string(b))
 				return nil
 			}
 		},
@@ -87,7 +111,7 @@ func getPacksCommand() cli.Command {
 
 			// if name wasn't provided, list all packs
 			if name == "" {
-				packs, err := fleet.GetPackSpecs()
+				packs, err := fleet.GetPacks()
 				if err != nil {
 					return errors.Wrap(err, "could not list packs")
 				}
@@ -114,7 +138,23 @@ func getPacksCommand() cli.Command {
 
 				return nil
 			} else {
-				fmt.Println("[+] Getting information on a specific pack is not currently supported")
+				pack, err := fleet.GetPack(name)
+				if err != nil {
+					return err
+				}
+
+				spec := specGeneric{
+					Kind:    "pack",
+					Version: kolide.ApiVersion,
+					Spec:    pack,
+				}
+
+				b, err := yaml.Marshal(spec)
+				if err != nil {
+					return err
+				}
+
+				fmt.Printf(string(b))
 				return nil
 			}
 		},
@@ -140,7 +180,7 @@ func getLabelsCommand() cli.Command {
 
 			// if name wasn't provided, list all labels
 			if name == "" {
-				labels, err := fleet.GetLabelSpecs()
+				labels, err := fleet.GetLabels()
 				if err != nil {
 					return errors.Wrap(err, "could not list labels")
 				}
@@ -168,7 +208,24 @@ func getLabelsCommand() cli.Command {
 
 				return nil
 			} else {
-				fmt.Println("[+] Getting information on a specific label is not currently supported")
+				label, err := fleet.GetLabel(name)
+				if err != nil {
+					return err
+				}
+
+				spec := specGeneric{
+					Kind:    "label",
+					Version: kolide.ApiVersion,
+					Spec:    label,
+				}
+
+				b, err := yaml.Marshal(spec)
+				if err != nil {
+					return err
+				}
+
+				fmt.Printf(string(b))
+
 				return nil
 			}
 		},

--- a/cmd/fleetctl/get.go
+++ b/cmd/fleetctl/get.go
@@ -85,7 +85,7 @@ func getQueriesCommand() cli.Command {
 					return err
 				}
 
-				fmt.Printf(string(b))
+				fmt.Print(string(b))
 				return nil
 			}
 		},
@@ -154,7 +154,7 @@ func getPacksCommand() cli.Command {
 					return err
 				}
 
-				fmt.Printf(string(b))
+				fmt.Print(string(b))
 				return nil
 			}
 		},
@@ -224,7 +224,7 @@ func getLabelsCommand() cli.Command {
 					return err
 				}
 
-				fmt.Printf(string(b))
+				fmt.Print(string(b))
 
 				return nil
 			}

--- a/examples/config-many-files/labels.yml
+++ b/examples/config-many-files/labels.yml
@@ -2,36 +2,7 @@
 apiVersion: v1
 kind: label
 spec:
-  name: all_hosts
-  query: always_true
----
-apiVersion: v1
-kind: label
-spec:
-  name: macs
-  query: darwin_hosts
----
-apiVersion: v1
-kind: label
-spec:
-  name: ubuntu
-  query: ubuntu_hosts
----
-apiVersion: v1
-kind: label
-spec:
-  name: centos
-  query: centos_hosts
----
-apiVersion: v1
-kind: label
-spec:
-  name: windows
-  query: windows_hosts
----
-apiVersion: v1
-kind: label
-spec:
+  name: pending_updates
   query: pending_updates
   platforms:
     - darwin
@@ -39,4 +10,5 @@ spec:
 apiVersion: v1
 kind: label
 spec:
+  name: slack_not_running
   query: slack_not_running

--- a/examples/config-many-files/packs/osquery-monitoring.yml
+++ b/examples/config-many-files/packs/osquery-monitoring.yml
@@ -3,9 +3,6 @@ apiVersion: v1
 kind: pack
 spec:
   name: osquery_monitoring
-  targets:
-    labels:
-      - all_hosts
   queries:
     - query: osquery_version
       name: osquery_version_snapshot

--- a/examples/config-single-file.yml
+++ b/examples/config-single-file.yml
@@ -70,36 +70,7 @@ spec:
 apiVersion: v1
 kind: label
 spec:
-  name: all_hosts
-  query: always_true
----
-apiVersion: v1
-kind: label
-spec:
-  name: macs
-  query: darwin_hosts
----
-apiVersion: v1
-kind: label
-spec:
-  name: ubuntu
-  query: ubuntu_hosts
----
-apiVersion: v1
-kind: label
-spec:
-  name: centos
-  query: centos_hosts
----
-apiVersion: v1
-kind: label
-spec:
-  name: windows
-  query: windows_hosts
----
-apiVersion: v1
-kind: label
-spec:
+  query: name
   query: pending_updates
   platforms:
     - darwin
@@ -107,15 +78,13 @@ spec:
 apiVersion: v1
 kind: label
 spec:
+  name: slack_not_running
   query: slack_not_running
 ---
 apiVersion: v1
 kind: pack
 spec:
   name: osquery_monitoring
-  targets:
-    labels:
-      - all_hosts
   queries:
     - query: osquery_version
       name: osquery_version_snapshot

--- a/server/kolide/fleetctl.go
+++ b/server/kolide/fleetctl.go
@@ -1,3 +1,3 @@
 package kolide
 
-const ApiVersion = "k8s.kolide.com/v1alpha1"
+const ApiVersion = "v1"


### PR DESCRIPTION
This PR adds support for getting resources by name.

```
$ fleetctl get queries
no queries found

$ fleetctl apply -f ./query.yaml
[+] applied 1 queries

$ fleetctl get queries
+-----------------+--------------------------------+--------------------------------+
|      NAME       |          DESCRIPTION           |             QUERY              |
+-----------------+--------------------------------+--------------------------------+
| osquery_version | The version of the Launcher    | select launcher.version,       |
|                 | and Osquery process            | osquery.version from           |
|                 |                                | kolide_launcher_info launcher, |
|                 |                                | osquery_info osquery;          |
+-----------------+--------------------------------+--------------------------------+

$ fleetctl get query osquery_version
apiVersion: v1
kind: query
spec:
  description: The version of the Launcher and Osquery process
  name: osquery_version
  query: select launcher.version, osquery.version from kolide_launcher_info launcher,
    osquery_info osquery;
```