### PR TITLE
ensure email and passwords are set during setup

### DIFF
--- a/cmd/fleetctl/setup.go
+++ b/cmd/fleetctl/setup.go
@@ -49,6 +49,12 @@ func setupCommand() cli.Command {
 				return err
 			}
 
+			if flEmail == "" {
+				return errors.Errorf("Email of the admin user to create must be provided")
+			}
+			if flPassword == "" {
+				return errors.Errorf("Password for the admin user to create must be provided")
+			}
 			token, err := fleet.Setup(flEmail, flPassword, flOrgName)
 			if err != nil {
 				switch err.(type) {

--- a/server/service/endpoint_setup.go
+++ b/server/service/endpoint_setup.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-kit/kit/endpoint"
 	"github.com/kolide/fleet/server/kolide"
+	"github.com/pkg/errors"
 )
 
 type setupRequest struct {
@@ -51,6 +52,14 @@ func makeSetupEndpoint(svc kolide.Service) endpoint.Endpoint {
 		// creating the user should be the last action. If there's a user
 		// present and other errors occur, the setup endpoint closes.
 		if req.Admin != nil {
+			if *req.Admin.Email == "" {
+				err := errors.Errorf("admin email cannot be empty")
+				return setupResponse{Err: err}, nil
+			}
+			if *req.Admin.Password == "" {
+				err := errors.Errorf("admin password cannot be empty")
+				return setupResponse{Err: err}, nil
+			}
 			admin, err = svc.NewAdminCreatedUser(ctx, *req.Admin)
 			if err != nil {
 				return setupResponse{Err: err}, nil


### PR DESCRIPTION
Caused me a wee bit of confusion, when toying with `fleetctl setup`.

This boils down to the setup endpoint not being wrapped in the usual validation middleware,
figured this should be fine, as all other knobs can be managed after login (Name, username,
orgname etc).