### PR TITLE
server: formatting

### DIFF
--- a/server/kolide/hosts.go
+++ b/server/kolide/hosts.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"net"
+	"strings"
 	"time"
-        "net"
-        "strings"
 )
 
 const (
@@ -134,18 +134,18 @@ func (h *Host) ResetPrimaryNetwork() bool {
 	// nics are in descending order of IO
 	// so we default to the most active nic
 	if len(h.NetworkInterfaces) > 0 {
-                // Check IPv4 address
+		// Check IPv4 address
 		for _, nic := range h.NetworkInterfaces {
-                        if strings.Index(nic.IPAddress, "127.") == 0 {
-                            continue
-                        }
-                        var isIpAddress = net.ParseIP(nic.IPAddress)
-                        if isIpAddress.To4() != nil {
-                            h.PrimaryNetworkInterfaceID = &nic.ID
-                            return true
-                        }
+			if strings.Index(nic.IPAddress, "127.") == 0 {
+				continue
+			}
+			var isIpAddress = net.ParseIP(nic.IPAddress)
+			if isIpAddress.To4() != nil {
+				h.PrimaryNetworkInterfaceID = &nic.ID
+				return true
+			}
 		}
-                // return IPv6 or other nic in place of IPv4
+		// return IPv6 or other nic in place of IPv4
 		h.PrimaryNetworkInterfaceID = &h.NetworkInterfaces[0].ID
 		return true
 	}

--- a/server/service/service_fim.go
+++ b/server/service/service_fim.go
@@ -2,10 +2,10 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/kolide/fleet/server/kolide"
 	"github.com/pkg/errors"
-	"encoding/json"
 )
 
 func (svc service) GetFIM(ctx context.Context) (*kolide.FIMConfig, error) {
@@ -26,8 +26,8 @@ func (svc service) GetFIM(ctx context.Context) (*kolide.FIMConfig, error) {
 	}
 
 	result := &kolide.FIMConfig{
-		Interval:  uint(config.FIMInterval),
-		FilePaths: paths,
+		Interval:     uint(config.FIMInterval),
+		FilePaths:    paths,
 		FileAccesses: arr,
 	}
 	return result, nil

--- a/server/service/service_fim_test.go
+++ b/server/service/service_fim_test.go
@@ -19,7 +19,7 @@ func TestGetFIMService(t *testing.T) {
 		AppConfigStore: mock.AppConfigStore{
 			AppConfigFunc: func() (*kolide.AppConfig, error) {
 				config := &kolide.AppConfig{
-					FIMInterval: fimIntervalTestValue,
+					FIMInterval:     fimIntervalTestValue,
 					FIMFileAccesses: fileAccessesString,
 				}
 				return config, nil
@@ -59,7 +59,7 @@ func TestUpdateFIM(t *testing.T) {
 		AppConfigStore: mock.AppConfigStore{
 			AppConfigFunc: func() (*kolide.AppConfig, error) {
 				config := &kolide.AppConfig{
-					FIMInterval: fimIntervalTestValue,
+					FIMInterval:     fimIntervalTestValue,
 					FIMFileAccesses: fileAccessesString,
 				}
 				return config, nil
@@ -82,7 +82,7 @@ func TestUpdateFIM(t *testing.T) {
 		ds: ds,
 	}
 	fim := kolide.FIMConfig{
-		Interval: uint(fimIntervalTestValue),
+		Interval:     uint(fimIntervalTestValue),
 		FileAccesses: fileAccessStringValue,
 		FilePaths: kolide.FIMSections{
 			"etc": []string{


### PR DESCRIPTION
My editor is pretty zealous about running `go fmt` 😁 

Any objections to adding lint targets to `circleci`  ?

It would be mess right now to add all of [golint](https://github.com/golang/lint) without a bunch of ignore handling, but `gofmt` should be there just to reduce accidental noise in diffs ?