### PR TITLE
passes allowNativePasswords DSN setting

### DIFF
--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -272,7 +272,7 @@ func registerTLS(config config.MysqlConfig) error {
 // provided configuration.
 func generateMysqlConnectionString(conf config.MysqlConfig) string {
 	dsn := fmt.Sprintf(
-		"%s:%s@(%s)/%s?charset=utf8mb4&parseTime=true&loc=UTC&clientFoundRows=true",
+		"%s:%s@(%s)/%s?charset=utf8mb4&parseTime=true&loc=UTC&clientFoundRows=true&allowNativePasswords=true",
 		conf.Username,
 		conf.Password,
 		conf.Address,


### PR DESCRIPTION
Azure's MySQL implementation appears to always respond with an Authentication Method Switch Request Packet requesting mysql_native_password auth even though the client's initial Handshake Response already included the native password credentials.

Most MySQL client libraries support this but Golang's go-sql-driver/mysql requires the allowNativePasswords DSN parameter set to enable it. Without this parameter, Fleet fails to authenticate to the database with the error message "this user requires mysql native password authentication."

References:

    https://web.archive.org/web/20160814002743/http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::AuthSwitchRequest
    https://web.archive.org/web/20160814002743/http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::HandshakeResponse
    https://github.com/go-sql-driver/mysql#user-content-allownativepasswords
