### PR TITLE
Fix labels UI errors in Fleet 2.0

### DIFF
--- a/server/datastore/datastore_labels_test.go
+++ b/server/datastore/datastore_labels_test.go
@@ -473,3 +473,22 @@ func testLabelIDsByName(t *testing.T, ds kolide.Datastore) {
 	sort.Slice(labels, func(i, j int) bool { return labels[i] < labels[j] })
 	assert.Equal(t, []uint{1, 2, 3}, labels)
 }
+
+func testSaveLabel(t *testing.T, db kolide.Datastore) {
+	label := &kolide.Label{
+		Name:        "my label",
+		Description: "a label",
+		Query:       "select 1 from processes;",
+		Platform:    "darwin",
+	}
+	label, err := db.NewLabel(label)
+	require.Nil(t, err)
+	label.Name = "changed name"
+	label.Description = "changed description"
+	_, err = db.SaveLabel(label)
+	require.Nil(t, err)
+	saved, err := db.Label(label.ID)
+	require.Nil(t, err)
+	assert.Equal(t, label.Name, saved.Name)
+	assert.Equal(t, label.Description, saved.Description)
+}

--- a/server/datastore/datastore_test.go
+++ b/server/datastore/datastore_test.go
@@ -31,6 +31,7 @@ var testFunctions = [...]func(*testing.T, kolide.Datastore){
 	testEnrollHost,
 	testAuthenticateHost,
 	testLabels,
+	testSaveLabel,
 	testManagingLabelsOnPacks,
 	testPasswordResetRequests,
 	testCreateUser,

--- a/server/kolide/labels.go
+++ b/server/kolide/labels.go
@@ -15,6 +15,8 @@ type LabelStore interface {
 	GetLabelSpec(name string) (*LabelSpec, error)
 
 	// Label methods
+	NewLabel(Label *Label, opts ...OptionalArg) (*Label, error)
+	SaveLabel(label *Label) (*Label, error)
 	DeleteLabel(name string) error
 	Label(lid uint) (*Label, error)
 	ListLabels(opt ListOptions) ([]*Label, error)
@@ -59,6 +61,8 @@ type LabelService interface {
 	// GetLabelSpec gets the spec for the label with the given name.
 	GetLabelSpec(ctx context.Context, name string) (*LabelSpec, error)
 
+	NewLabel(ctx context.Context, p LabelPayload) (label *Label, err error)
+	ModifyLabel(ctx context.Context, id uint, payload ModifyLabelPayload) (*Label, error)
 	ListLabels(ctx context.Context, opt ListOptions) (labels []*Label, err error)
 	GetLabel(ctx context.Context, id uint) (label *Label, err error)
 
@@ -67,6 +71,12 @@ type LabelService interface {
 	// HostIDsForLabel returns ids of hosts that belong to the label identified
 	// by lid
 	HostIDsForLabel(lid uint) ([]uint, error)
+}
+
+// ModifyLabelPayload is used to change editable fields for a Label
+type ModifyLabelPayload struct {
+	Name        *string `json:"name"`
+	Description *string `json:"description"`
 }
 
 type LabelPayload struct {

--- a/server/mock/datastore_labels.go
+++ b/server/mock/datastore_labels.go
@@ -16,6 +16,10 @@ type GetLabelSpecsFunc func() ([]*kolide.LabelSpec, error)
 
 type GetLabelSpecFunc func(name string) (*kolide.LabelSpec, error)
 
+type NewLabelFunc func(Label *kolide.Label, opts ...kolide.OptionalArg) (*kolide.Label, error)
+
+type SaveLabelFunc func(label *kolide.Label) (*kolide.Label, error)
+
 type DeleteLabelFunc func(name string) error
 
 type LabelFunc func(lid uint) (*kolide.Label, error)
@@ -45,6 +49,12 @@ type LabelStore struct {
 
 	GetLabelSpecFunc        GetLabelSpecFunc
 	GetLabelSpecFuncInvoked bool
+
+	NewLabelFunc        NewLabelFunc
+	NewLabelFuncInvoked bool
+
+	SaveLabelFunc        SaveLabelFunc
+	SaveLabelFuncInvoked bool
 
 	DeleteLabelFunc        DeleteLabelFunc
 	DeleteLabelFuncInvoked bool
@@ -90,6 +100,16 @@ func (s *LabelStore) GetLabelSpecs() ([]*kolide.LabelSpec, error) {
 func (s *LabelStore) GetLabelSpec(name string) (*kolide.LabelSpec, error) {
 	s.GetLabelSpecFuncInvoked = true
 	return s.GetLabelSpecFunc(name)
+}
+
+func (s *LabelStore) NewLabel(Label *kolide.Label, opts ...kolide.OptionalArg) (*kolide.Label, error) {
+	s.NewLabelFuncInvoked = true
+	return s.NewLabelFunc(Label, opts...)
+}
+
+func (s *LabelStore) SaveLabel(label *kolide.Label) (*kolide.Label, error) {
+	s.SaveLabelFuncInvoked = true
+	return s.SaveLabelFunc(label)
 }
 
 func (s *LabelStore) DeleteLabel(name string) error {

--- a/server/service/endpoint_labels.go
+++ b/server/service/endpoint_labels.go
@@ -68,6 +68,72 @@ func makeGetLabelEndpoint(svc kolide.Service) endpoint.Endpoint {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Create Label
+////////////////////////////////////////////////////////////////////////////////
+
+type createLabelRequest struct {
+	payload kolide.LabelPayload
+}
+
+type createLabelResponse struct {
+	Label labelResponse `json:"label"`
+	Err   error         `json:"error,omitempty"`
+}
+
+func (r createLabelResponse) error() error { return r.Err }
+
+func makeCreateLabelEndpoint(svc kolide.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(createLabelRequest)
+
+		label, err := svc.NewLabel(ctx, req.payload)
+		if err != nil {
+			return createLabelResponse{Err: err}, nil
+		}
+
+		labelResp, err := labelResponseForLabel(ctx, svc, label)
+		if err != nil {
+			return createLabelResponse{Err: err}, nil
+		}
+
+		return createLabelResponse{Label: *labelResp}, nil
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Modify Label
+////////////////////////////////////////////////////////////////////////////////
+
+type modifyLabelRequest struct {
+	ID      uint
+	payload kolide.ModifyLabelPayload
+}
+
+type modifyLabelResponse struct {
+	Label labelResponse `json:"label"`
+	Err   error         `json:"error,omitempty"`
+}
+
+func (r modifyLabelResponse) error() error { return r.Err }
+
+func makeModifyLabelEndpoint(svc kolide.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(modifyLabelRequest)
+		label, err := svc.ModifyLabel(ctx, req.ID, req.payload)
+		if err != nil {
+			return modifyLabelResponse{Err: err}, nil
+		}
+
+		labelResp, err := labelResponseForLabel(ctx, svc, label)
+		if err != nil {
+			return modifyLabelResponse{Err: err}, nil
+		}
+
+		return modifyLabelResponse{Label: *labelResp}, err
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // List Labels
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -70,6 +70,8 @@ type KolideEndpoints struct {
 	GetDistributedQueries                 endpoint.Endpoint
 	SubmitDistributedQueryResults         endpoint.Endpoint
 	SubmitLogs                            endpoint.Endpoint
+	CreateLabel                           endpoint.Endpoint
+	ModifyLabel                           endpoint.Endpoint
 	GetLabel                              endpoint.Endpoint
 	ListLabels                            endpoint.Endpoint
 	DeleteLabel                           endpoint.Endpoint
@@ -165,6 +167,8 @@ func MakeKolideServerEndpoints(svc kolide.Service, jwtKey string) KolideEndpoint
 		ListHosts:                             authenticatedUser(jwtKey, svc, makeListHostsEndpoint(svc)),
 		GetHostSummary:                        authenticatedUser(jwtKey, svc, makeGetHostSummaryEndpoint(svc)),
 		DeleteHost:                            authenticatedUser(jwtKey, svc, makeDeleteHostEndpoint(svc)),
+		CreateLabel:                           authenticatedUser(jwtKey, svc, makeCreateLabelEndpoint(svc)),
+		ModifyLabel:                           authenticatedUser(jwtKey, svc, makeModifyLabelEndpoint(svc)),
 		GetLabel:                              authenticatedUser(jwtKey, svc, makeGetLabelEndpoint(svc)),
 		ListLabels:                            authenticatedUser(jwtKey, svc, makeListLabelsEndpoint(svc)),
 		DeleteLabel:                           authenticatedUser(jwtKey, svc, makeDeleteLabelEndpoint(svc)),
@@ -247,6 +251,8 @@ type kolideHandlers struct {
 	GetDistributedQueries                 http.Handler
 	SubmitDistributedQueryResults         http.Handler
 	SubmitLogs                            http.Handler
+	CreateLabel                           http.Handler
+	ModifyLabel                           http.Handler
 	GetLabel                              http.Handler
 	ListLabels                            http.Handler
 	DeleteLabel                           http.Handler
@@ -332,6 +338,8 @@ func makeKolideKitHandlers(e KolideEndpoints, opts []kithttp.ServerOption) *koli
 		GetDistributedQueries:                 newServer(e.GetDistributedQueries, decodeGetDistributedQueriesRequest),
 		SubmitDistributedQueryResults:         newServer(e.SubmitDistributedQueryResults, decodeSubmitDistributedQueryResultsRequest),
 		SubmitLogs:                            newServer(e.SubmitLogs, decodeSubmitLogsRequest),
+		CreateLabel:                           newServer(e.CreateLabel, decodeCreateLabelRequest),
+		ModifyLabel:                           newServer(e.ModifyLabel, decodeModifyLabelRequest),
 		GetLabel:                              newServer(e.GetLabel, decodeGetLabelRequest),
 		ListLabels:                            newServer(e.ListLabels, decodeListLabelsRequest),
 		DeleteLabel:                           newServer(e.DeleteLabel, decodeDeleteLabelRequest),
@@ -458,6 +466,8 @@ func attachKolideAPIRoutes(r *mux.Router, h *kolideHandlers) {
 	r.Handle("/api/v1/kolide/spec/packs", h.GetPackSpecs).Methods("GET").Name("get_pack_specs")
 	r.Handle("/api/v1/kolide/spec/packs/{name}", h.GetPackSpec).Methods("GET").Name("get_pack_spec")
 
+	r.Handle("/api/v1/kolide/labels", h.CreateLabel).Methods("POST").Name("create_label")
+	r.Handle("/api/v1/kolide/labels/{id}", h.ModifyLabel).Methods("PATCH").Name("modify_label")
 	r.Handle("/api/v1/kolide/labels/{id}", h.GetLabel).Methods("GET").Name("get_label")
 	r.Handle("/api/v1/kolide/labels", h.ListLabels).Methods("GET").Name("list_labels")
 	r.Handle("/api/v1/kolide/labels/{name}", h.DeleteLabel).Methods("DELETE").Name("delete_label")

--- a/server/service/logging_labels.go
+++ b/server/service/logging_labels.go
@@ -7,6 +7,42 @@ import (
 	"github.com/kolide/fleet/server/kolide"
 )
 
+func (mw loggingMiddleware) NewLabel(ctx context.Context, p kolide.LabelPayload) (*kolide.Label, error) {
+	var (
+		label *kolide.Label
+		err   error
+	)
+
+	defer func(begin time.Time) {
+		_ = mw.logger.Log(
+			"method", "NewLabel",
+			"err", err,
+			"took", time.Since(begin),
+		)
+	}(time.Now())
+
+	label, err = mw.Service.NewLabel(ctx, p)
+	return label, err
+}
+
+func (mw loggingMiddleware) ModifyLabel(ctx context.Context, id uint, p kolide.ModifyLabelPayload) (*kolide.Label, error) {
+	var (
+		label *kolide.Label
+		err   error
+	)
+
+	defer func(begin time.Time) {
+		mw.logger.Log(
+			"method", "ModifyLabel",
+			"err", err,
+			"took", time.Since(begin),
+		)
+	}(time.Now())
+
+	label, err = mw.Service.ModifyLabel(ctx, id, p)
+	return label, err
+}
+
 func (mw loggingMiddleware) ListLabels(ctx context.Context, opt kolide.ListOptions) ([]*kolide.Label, error) {
 	var (
 		labels []*kolide.Label

--- a/server/service/metrics_labels.go
+++ b/server/service/metrics_labels.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/kolide/fleet/server/kolide"
+)
+
+func (mw metricsMiddleware) ModifyLabel(ctx context.Context, id uint, p kolide.ModifyLabelPayload) (*kolide.Label, error) {
+	var (
+		lic *kolide.Label
+		err error
+	)
+	defer func(begin time.Time) {
+		lvs := []string{"method", "ModifyLabel", "error", fmt.Sprint(err != nil)}
+		mw.requestCount.With(lvs...).Add(1)
+		mw.requestLatency.With(lvs...).Observe(time.Since(begin).Seconds())
+	}(time.Now())
+	lic, err = mw.Service.ModifyLabel(ctx, id, p)
+	return lic, err
+
+}

--- a/server/service/service_labels.go
+++ b/server/service/service_labels.go
@@ -18,6 +18,48 @@ func (svc service) GetLabelSpec(ctx context.Context, name string) (*kolide.Label
 	return svc.ds.GetLabelSpec(name)
 }
 
+func (svc service) NewLabel(ctx context.Context, p kolide.LabelPayload) (*kolide.Label, error) {
+	label := &kolide.Label{}
+
+	if p.Name == nil {
+		return nil, newInvalidArgumentError("name", "missing required argument")
+	}
+	label.Name = *p.Name
+
+	if p.Query == nil {
+		return nil, newInvalidArgumentError("query", "missing required argument")
+	}
+	label.Query = *p.Query
+
+	if p.Platform != nil {
+		label.Platform = *p.Platform
+	}
+
+	if p.Description != nil {
+		label.Description = *p.Description
+	}
+
+	label, err := svc.ds.NewLabel(label)
+	if err != nil {
+		return nil, err
+	}
+	return label, nil
+}
+
+func (svc service) ModifyLabel(ctx context.Context, id uint, payload kolide.ModifyLabelPayload) (*kolide.Label, error) {
+	label, err := svc.ds.Label(id)
+	if err != nil {
+		return nil, err
+	}
+	if payload.Name != nil {
+		label.Name = *payload.Name
+	}
+	if payload.Description != nil {
+		label.Description = *payload.Description
+	}
+	return svc.ds.SaveLabel(label)
+}
+
 func (svc service) ListLabels(ctx context.Context, opt kolide.ListOptions) ([]*kolide.Label, error) {
 	return svc.ds.ListLabels(opt)
 }

--- a/server/service/transport_labels.go
+++ b/server/service/transport_labels.go
@@ -42,3 +42,25 @@ func decodeApplyLabelSpecsRequest(ctx context.Context, r *http.Request) (interfa
 	return req, nil
 
 }
+
+func decodeCreateLabelRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	var req createLabelRequest
+	if err := json.NewDecoder(r.Body).Decode(&req.payload); err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
+func decodeModifyLabelRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	id, err := idFromRequest(r, "id")
+	if err != nil {
+		return nil, err
+	}
+	var resp modifyLabelRequest
+	err = json.NewDecoder(r.Body).Decode(&resp.payload)
+	if err != nil {
+		return nil, err
+	}
+	resp.ID = id
+	return resp, nil
+}

--- a/server/service/transport_labels_test.go
+++ b/server/service/transport_labels_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -39,5 +40,30 @@ func TestDecodeGetLabelRequest(t *testing.T) {
 	router.ServeHTTP(
 		httptest.NewRecorder(),
 		httptest.NewRequest("GET", "/api/v1/kolide/labels/1", nil),
+	)
+}
+
+func TestDecodeCreateLabelRequest(t *testing.T) {
+	router := mux.NewRouter()
+	router.HandleFunc("/api/v1/kolide/labels", func(writer http.ResponseWriter, request *http.Request) {
+		r, err := decodeCreateLabelRequest(context.Background(), request)
+		assert.Nil(t, err)
+
+		params := r.(createLabelRequest)
+		assert.Equal(t, "foo", *params.payload.Name)
+		assert.Equal(t, "select * from foo;", *params.payload.Query)
+		assert.Equal(t, "darwin", *params.payload.Platform)
+	}).Methods("POST")
+
+	var body bytes.Buffer
+	body.Write([]byte(`{
+        "name": "foo",
+        "query": "select * from foo;",
+		"platform": "darwin"
+    }`))
+
+	router.ServeHTTP(
+		httptest.NewRecorder(),
+		httptest.NewRequest("POST", "/api/v1/kolide/labels", &body),
 	)
 }


### PR DESCRIPTION
Replaces the UI endpoints for creating and modifying labels. These were removed
in #1686 because we thought we were killing the UI.

Now labels can be created and edited in the UI again.