### PR TITLE
Fix newline handling in fleetctl convert

### DIFF
--- a/cmd/fleetctl/convert.go
+++ b/cmd/fleetctl/convert.go
@@ -104,7 +104,7 @@ func convertCommand() cli.Command {
 			// valid JSON but osquery accepts them) and replace
 			// with \n so that we get them in the YAML output where
 			// they are allowed.
-			re := regexp.MustCompile(`\W*\\\n`)
+			re := regexp.MustCompile(`\s*\\\n`)
 			b = re.ReplaceAll(b, []byte(`\n`))
 
 			var specs *specGroup


### PR DESCRIPTION
Previously we stripped all non-word characters which worked for some cases, but
removed necessary characters in others. What we really want (and now do) is to
remove only whitespace characters.

Fixes #1854