### PR TITLE
Expose API Token in UI

### DIFF
--- a/frontend/components/hosts/AddHostModal/AddHostModal.jsx
+++ b/frontend/components/hosts/AddHostModal/AddHostModal.jsx
@@ -4,7 +4,7 @@ import Button from 'components/buttons/Button';
 import Icon from 'components/icons/Icon';
 import InputField from 'components/forms/fields/InputField';
 import { renderFlash } from 'redux/nodes/notifications/actions';
-import { copyText } from './helpers';
+import { copyText } from 'utilities/copy_text';
 import certificate from '../../../../assets/images/osquery-certificate.svg';
 
 const baseClass = 'add-host-modal';

--- a/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
+++ b/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
@@ -2,7 +2,8 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { goBack } from 'react-router-redux';
 import moment from 'moment';
-import local from 'utilities/local';
+import { authToken } from 'utilities/local';
+import { copyText } from 'utilities/copy_text';
 
 import Avatar from 'components/Avatar';
 import Button from 'components/buttons/Button';
@@ -237,14 +238,14 @@ export class UserSettingsPage extends Component {
         onExit={onToggleApiTokenModal}
       >
           The following is your API Token:
-          <a href="#revealSecret" onClick={toggleSecret} className={`${baseClass}__reveal-secret`}>{revealSecret ? 'Hide' : 'Reveal'} Secret</a>
+          <a href="#revealSecret" onClick={toggleSecret} className={`${baseClass}__reveal-secret`}>{revealSecret ? 'Hide' : 'Reveal'} Token</a>
               <div className={`${baseClass}__secret-wrapper`}>
                 <InputField
                   disabled
                   inputWrapperClass={`${baseClass}__secret-input`}
                   name="osqueryd-secret"
                   type={revealSecret ? 'text' : 'password'}
-                  value={local.getItem('auth_token')}
+                  value={authToken()}
                 />
                 <Button variant="unstyled" className={`${baseClass}__secret-copy-icon`} onClick={onCopySecret(`.${baseClass}__secret-input`)}>
                   <Icon name="clipboard" />

--- a/frontend/utilities/copy_text.js
+++ b/frontend/utilities/copy_text.js
@@ -26,5 +26,3 @@ export const copyText = (elementSelector) => {
   removeSelectedText();
   return true;
 };
-
-export default { copyText };


### PR DESCRIPTION
Useful for SAML login users who cannot log in with `fleetctl login`. Instead
they can pull their session token from the UI and configure the fleetctl client
to use it.