### PR TITLE
Fleetctl query improvements

### DIFF
--- a/cmd/fleetctl/query.go
+++ b/cmd/fleetctl/query.go
@@ -106,9 +106,11 @@ func queryCommand() cli.Command {
 				select {
 				case hostResult := <-res.Results():
 					out := resultOutput{hostResult.Host.HostName, hostResult.Rows}
+					s.Stop()
 					if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
 						fmt.Fprintf(os.Stderr, "Error writing output: %s\n", err)
 					}
+					s.Start()
 
 				case err := <-res.Errors():
 					fmt.Fprintf(os.Stderr, "Error talking to server: %s\n", err.Error())

--- a/cmd/fleetctl/query.go
+++ b/cmd/fleetctl/query.go
@@ -137,13 +137,16 @@ func queryCommand() cli.Command {
 						return nil
 					}
 
+					msg := fmt.Sprintf(" %.f%% responded (%.f%% online) | %d/%d targeted hosts (%d/%d online)", percentTotal, percentOnline, responded, total, responded, online)
 					if !flQuiet {
-						s.Suffix = fmt.Sprintf(
-							"  %.f%% responded (%.f%% online) | %d/%d targeted hosts (%d/%d online)",
-							percentTotal, percentOnline,
-							responded, total,
-							responded, online,
-						)
+						s.Suffix = msg
+					}
+					if total == responded {
+						s.Stop()
+						if !flQuiet {
+							fmt.Fprintf(os.Stderr, msg+"\n")
+						}
+						return nil
 					}
 				}
 			}


### PR DESCRIPTION
There is no reason to keep looping on results when all hosts in the fleet have responded, so exit
when that happens. 

An option to exit when all online hosts have responded might be useful, but isn't included in this
PR.

Pausing the spinner when outputting prevents "ugly" output on the terminal when stderr isn't
redirected to /dev/null.