### PR TITLE
Run make generate before make docker-build-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ else
 	rm -f assets/bundle.js
 endif
 
-docker-build-release: .pre-fleet
+docker-build-release: .pre-fleet generate
 	GOOS=linux go build -i -o build/linux/${OUTPUT} -ldflags ${KIT_VERSION} ./cmd/fleet
 	docker build -t "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" .
 	docker tag "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" kolide/fleet:latest


### PR DESCRIPTION
Ensure that assets are compiled before building Docker images. In the past we
have accidentally published images that were lacking assets.