### PR TITLE
Display errors on password reset page

### DIFF
--- a/frontend/pages/ResetPasswordPage/ResetPasswordPage.jsx
+++ b/frontend/pages/ResetPasswordPage/ResetPasswordPage.jsx
@@ -102,11 +102,12 @@ export class ResetPasswordPage extends Component {
 
 const mapStateToProps = (state) => {
   const { ResetPasswordPage: componentState } = state.components;
-  const { user } = state.auth;
+  const { user, errors } = state.auth;
 
   return {
     ...componentState,
     user,
+    errors,
   };
 };
 


### PR DESCRIPTION
Correctly map the state to props so that errors are displayed.

Fixes #1885 
