### PR TITLE
Delete packs that have already been soft-deleted

### DIFF
--- a/server/datastore/mysql/migrations/data/20171212182459_DeleteSoftDeletedPacks.go
+++ b/server/datastore/mysql/migrations/data/20171212182459_DeleteSoftDeletedPacks.go
@@ -1,0 +1,23 @@
+package data
+
+import (
+	"database/sql"
+
+	"github.com/pkg/errors"
+)
+
+func init() {
+	MigrationClient.AddMigration(Up20171212182459, Down20171212182459)
+}
+
+func Up20171212182459(tx *sql.Tx) error {
+	sql := `DELETE FROM packs WHERE deleted = 1`
+	if _, err := tx.Exec(sql); err != nil {
+		return errors.Wrap(err, "delete packs")
+	}
+	return nil
+}
+
+func Down20171212182459(tx *sql.Tx) error {
+	return nil
+}


### PR DESCRIPTION
We no longer use soft deletion, so this commit introduces a migration that hard
deletes existing deleted packs.

Fixes #1923