### PR TITLE
Documentation: Add mysql conn limits 

### DIFF
--- a/docs/infrastructure/configuring-the-fleet-binary.md
+++ b/docs/infrastructure/configuring-the-fleet-binary.md
@@ -224,6 +224,32 @@ The server name or IP address used by the client certificate.
 		servername: 127.0.0.1
 	```
 
+##### `mysql_max_open_conns`
+
+Maximum open connections to database
+
+- Default value: 50
+- Environment variable: `KOLIDE_MYSQL_MAX_OPEN_CONNS`
+- Config file format:
+
+	```
+	mysql:
+		max_open_conns: 50
+	```
+
+##### `mysql_max_idle_conns`
+
+Maximum idle connections to database. This value should be equal to or less than `mysql_max_open_conns`
+
+- Default value: 50
+- Environment variable: `KOLIDE_MYSQL_MAX_IDLE_CONNS`
+- Config file format:
+
+	```
+	mysql:
+		max_idle_conns: 50
+	```
+
 #### Redis
 
 ##### `redis_address`

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -24,7 +24,7 @@ type Client struct {
 
 func NewClient(addr string, insecureSkipVerify bool, rootCA string) (*Client, error) {
 	if !strings.HasPrefix(addr, "https://") {
-		return nil, errors.New("Addrress must start with https://")
+		return nil, errors.New("Address must start with https://")
 	}
 
 	baseURL, err := url.Parse(addr)


### PR DESCRIPTION
The 'max_open_conns' and 'max_idle_conns' settings seem to be missing. I was referencing the config struct in 'server/config/config.go'