### PR TITLE
Fix #1948: allow spaces in names for fleetctl

### DIFF
--- a/server/service/client_labels.go
+++ b/server/service/client_labels.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"path"
 
 	"github.com/kolide/fleet/server/kolide"
 	"github.com/pkg/errors"
@@ -42,8 +43,9 @@ func (c *Client) ApplyLabels(specs []*kolide.LabelSpec) error {
 
 // GetLabel retrieves information about a label by name
 func (c *Client) GetLabel(name string) (*kolide.LabelSpec, error) {
-	verb, path := "GET", "/api/v1/kolide/spec/labels/"+url.QueryEscape(name)
-	response, err := c.AuthenticatedDo(verb, path, nil)
+	u := &url.URL{Path: name}
+	verb, encodedPath := "GET", path.Join("/api/v1/kolide/spec/labels/", u.String())
+	response, err := c.AuthenticatedDo(verb, encodedPath, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "GET /api/v1/kolide/spec/labels")
 	}
@@ -105,10 +107,11 @@ func (c *Client) GetLabels() ([]*kolide.LabelSpec, error) {
 
 // DeleteLabel deletes the label with the matching name.
 func (c *Client) DeleteLabel(name string) error {
-	verb, path := "DELETE", "/api/v1/kolide/labels/"+url.QueryEscape(name)
-	response, err := c.AuthenticatedDo(verb, path, nil)
+	u := &url.URL{Path: name}
+	verb, encodedPath := "DELETE", path.Join("/api/v1/kolide/labels/", u.String())
+	response, err := c.AuthenticatedDo(verb, encodedPath, nil)
 	if err != nil {
-		return errors.Wrapf(err, "%s %s", verb, path)
+		return errors.Wrapf(err, "%s %s", verb, encodedPath)
 	}
 	defer response.Body.Close()
 

--- a/server/service/client_packs.go
+++ b/server/service/client_packs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"path"
 
 	"github.com/kolide/fleet/server/kolide"
 	"github.com/pkg/errors"
@@ -42,8 +43,9 @@ func (c *Client) ApplyPacks(specs []*kolide.PackSpec) error {
 
 // GetPack retrieves information about a pack
 func (c *Client) GetPack(name string) (*kolide.PackSpec, error) {
-	verb, path := "GET", "/api/v1/kolide/spec/packs/"+url.QueryEscape(name)
-	response, err := c.AuthenticatedDo(verb, path, nil)
+	u := &url.URL{Path: name}
+	verb, encodedPath := "GET", path.Join("/api/v1/kolide/spec/packs/", u.String())
+	response, err := c.AuthenticatedDo(verb, encodedPath, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "GET /api/v1/kolide/spec/packs")
 	}
@@ -105,10 +107,11 @@ func (c *Client) GetPacks() ([]*kolide.PackSpec, error) {
 
 // DeletePack deletes the pack with the matching name.
 func (c *Client) DeletePack(name string) error {
-	verb, path := "DELETE", "/api/v1/kolide/packs/"+url.QueryEscape(name)
-	response, err := c.AuthenticatedDo(verb, path, nil)
+	u := &url.URL{Path: name}
+	verb, encodedPath := "DELETE", path.Join("/api/v1/kolide/packs/", u.String())
+	response, err := c.AuthenticatedDo(verb, encodedPath, nil)
 	if err != nil {
-		return errors.Wrapf(err, "%s %s", verb, path)
+		return errors.Wrapf(err, "%s %s", verb, encodedPath)
 	}
 	defer response.Body.Close()
 

--- a/server/service/client_queries.go
+++ b/server/service/client_queries.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"path"
 
 	"github.com/kolide/fleet/server/kolide"
 	"github.com/pkg/errors"
@@ -42,10 +43,11 @@ func (c *Client) ApplyQueries(specs []*kolide.QuerySpec) error {
 
 // GetQuery retrieves the list of all Queries.
 func (c *Client) GetQuery(name string) (*kolide.QuerySpec, error) {
-	verb, path := "GET", "/api/v1/kolide/spec/queries/"+url.QueryEscape(name)
-	response, err := c.AuthenticatedDo(verb, path, nil)
+	u := &url.URL{Path: name}
+	verb, encodedPath := "GET", path.Join("/api/v1/kolide/spec/queries/", u.String())
+	response, err := c.AuthenticatedDo(verb, encodedPath, nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "%s %s", verb, path)
+		return nil, errors.Wrapf(err, "%s %s", verb, encodedPath)
 	}
 	defer response.Body.Close()
 
@@ -105,10 +107,11 @@ func (c *Client) GetQueries() ([]*kolide.QuerySpec, error) {
 
 // DeleteQuery deletes the query with the matching name.
 func (c *Client) DeleteQuery(name string) error {
-	verb, path := "DELETE", "/api/v1/kolide/queries/"+url.QueryEscape(name)
-	response, err := c.AuthenticatedDo(verb, path, nil)
+	u := &url.URL{Path: name}
+	verb, encodedPath := "DELETE", path.Join("/api/v1/kolide/queries/", u.String())
+	response, err := c.AuthenticatedDo(verb, encodedPath, nil)
 	if err != nil {
-		return errors.Wrapf(err, "%s %s", verb, path)
+		return errors.Wrapf(err, "%s %s", verb, encodedPath)
 	}
 	defer response.Body.Close()
 


### PR DESCRIPTION
* Use Go's url Path encoding to ensure client encodes spaces as "%20"
(decoded as space by Fleet API) rather than "+" (not decoded as space by
Fleet API).