### PR TITLE
Fix errors when trying to retrieve specs with spaces in name

### DIFF
--- a/server/service/client_labels.go
+++ b/server/service/client_labels.go
@@ -42,7 +42,7 @@ func (c *Client) ApplyLabels(specs []*kolide.LabelSpec) error {
 
 // GetLabel retrieves information about a label by name
 func (c *Client) GetLabel(name string) (*kolide.LabelSpec, error) {
-	verb, path := "GET", "/api/v1/kolide/spec/labels/"+url.QueryEscape(name)
+	verb, path := "GET", "/api/v1/kolide/spec/labels/"+url.PathEscape(name)
 	response, err := c.AuthenticatedDo(verb, path, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "GET /api/v1/kolide/spec/labels")
@@ -105,7 +105,7 @@ func (c *Client) GetLabels() ([]*kolide.LabelSpec, error) {
 
 // DeleteLabel deletes the label with the matching name.
 func (c *Client) DeleteLabel(name string) error {
-	verb, path := "DELETE", "/api/v1/kolide/labels/"+url.QueryEscape(name)
+	verb, path := "DELETE", "/api/v1/kolide/labels/"+url.PathEscape(name)
 	response, err := c.AuthenticatedDo(verb, path, nil)
 	if err != nil {
 		return errors.Wrapf(err, "%s %s", verb, path)

--- a/server/service/client_packs.go
+++ b/server/service/client_packs.go
@@ -42,7 +42,7 @@ func (c *Client) ApplyPacks(specs []*kolide.PackSpec) error {
 
 // GetPack retrieves information about a pack
 func (c *Client) GetPack(name string) (*kolide.PackSpec, error) {
-	verb, path := "GET", "/api/v1/kolide/spec/packs/"+url.QueryEscape(name)
+	verb, path := "GET", "/api/v1/kolide/spec/packs/"+url.PathEscape(name)
 	response, err := c.AuthenticatedDo(verb, path, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "GET /api/v1/kolide/spec/packs")
@@ -105,7 +105,7 @@ func (c *Client) GetPacks() ([]*kolide.PackSpec, error) {
 
 // DeletePack deletes the pack with the matching name.
 func (c *Client) DeletePack(name string) error {
-	verb, path := "DELETE", "/api/v1/kolide/packs/"+url.QueryEscape(name)
+	verb, path := "DELETE", "/api/v1/kolide/packs/"+url.PathEscape(name)
 	response, err := c.AuthenticatedDo(verb, path, nil)
 	if err != nil {
 		return errors.Wrapf(err, "%s %s", verb, path)

--- a/server/service/client_queries.go
+++ b/server/service/client_queries.go
@@ -42,7 +42,7 @@ func (c *Client) ApplyQueries(specs []*kolide.QuerySpec) error {
 
 // GetQuery retrieves the list of all Queries.
 func (c *Client) GetQuery(name string) (*kolide.QuerySpec, error) {
-	verb, path := "GET", "/api/v1/kolide/spec/queries/"+url.QueryEscape(name)
+	verb, path := "GET", "/api/v1/kolide/spec/queries/"+url.PathEscape(name)
 	response, err := c.AuthenticatedDo(verb, path, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "%s %s", verb, path)
@@ -105,7 +105,7 @@ func (c *Client) GetQueries() ([]*kolide.QuerySpec, error) {
 
 // DeleteQuery deletes the query with the matching name.
 func (c *Client) DeleteQuery(name string) error {
-	verb, path := "DELETE", "/api/v1/kolide/queries/"+url.QueryEscape(name)
+	verb, path := "DELETE", "/api/v1/kolide/queries/"+url.PathEscape(name)
 	response, err := c.AuthenticatedDo(verb, path, nil)
 	if err != nil {
 		return errors.Wrapf(err, "%s %s", verb, path)

--- a/server/service/transport.go
+++ b/server/service/transport.go
@@ -3,13 +3,14 @@ package service
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/gorilla/mux"
 	"github.com/kolide/fleet/server/kolide"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -74,7 +75,11 @@ func nameFromRequest(r *http.Request, varName string) (string, error) {
 	if !ok {
 		return "", errBadRoute
 	}
-	return name, nil
+	unescaped, err := url.PathUnescape(name)
+	if err != nil {
+		return "", errors.Wrap(err, "unescape name in path")
+	}
+	return unescaped, nil
 }
 
 // default number of items to include per page


### PR DESCRIPTION
We need to properly escape and unescape the name parameter.

Fixes #1948