### PR TITLE
Non-Quoted Interval Conversion

### DIFF
--- a/cmd/fleetctl/convert.go
+++ b/cmd/fleetctl/convert.go
@@ -43,6 +43,8 @@ func specGroupFromPack(name string, inputPack kolide.PermissivePackContent) (*sp
 			interval = uint(u64)
 		case uint:
 			interval = i
+		case float64:
+			interval = uint(i)
 		}
 
 		specs.Queries = append(specs.Queries, spec)


### PR DESCRIPTION
Found that when running `fleetctl convert -f ./mypack.yml`, observed that any of the non-quoted integer values (read as strings) were being converted to 0 in the final output.  Ran a simple test to determine when a number is Unmarshalled as an interface (https://github.com/kolide/fleet/blob/06832697d0e6ed6b2ca0220ef5434791db7b0a27/server/kolide/osquery.go#L52) it is of type `float64`.  Simply added a `float64` to the case statement and now non-quoted integers are being rendered correctly.