### PR TITLE
Add username support to fleetctl setup

### DIFF
--- a/cmd/fleetctl/setup.go
+++ b/cmd/fleetctl/setup.go
@@ -13,13 +13,14 @@ import (
 func setupCommand() cli.Command {
 	var (
 		flEmail    string
+		flUsername string
 		flPassword string
 		flOrgName  string
 	)
 	return cli.Command{
 		Name:      "setup",
 		Usage:     "Setup a Kolide Fleet instance",
-		UsageText: `fleetctl config login [options]`,
+		UsageText: `fleetctl setup [options]`,
 		Flags: []cli.Flag{
 			configFlag(),
 			contextFlag(),
@@ -29,6 +30,13 @@ func setupCommand() cli.Command {
 				Value:       "",
 				Destination: &flEmail,
 				Usage:       "Email of the admin user to create",
+			},
+			cli.StringFlag{
+				Name:        "username",
+				EnvVar:      "USERNAME",
+				Value:       "",
+				Destination: &flUsername,
+				Usage:       "Username of the admin user to create",
 			},
 			cli.StringFlag{
 				Name:        "password",
@@ -54,6 +62,10 @@ func setupCommand() cli.Command {
 			if flEmail == "" {
 				return errors.Errorf("Email of the admin user to create must be provided")
 			}
+			if flUsername == "" {
+				fmt.Println("No username supplied, using email as username")
+				flUsername = flEmail
+			}
 			if flPassword == "" {
 				fmt.Print("Password: ")
 				passBytes, err := terminal.ReadPassword(int(os.Stdin.Fd()))
@@ -75,7 +87,7 @@ func setupCommand() cli.Command {
 
 			}
 
-			token, err := fleet.Setup(flEmail, flPassword, flOrgName)
+			token, err := fleet.Setup(flEmail, flUsername, flPassword, flOrgName)
 			if err != nil {
 				switch err.(type) {
 				case service.SetupAlreadyErr:

--- a/server/service/client_setup.go
+++ b/server/service/client_setup.go
@@ -10,12 +10,12 @@ import (
 
 // Setup attempts to setup the current Fleet instance. If setup is successful,
 // an auth token is returned.
-func (c *Client) Setup(email, password, org string) (string, error) {
+func (c *Client) Setup(email, username, password, org string) (string, error) {
 	t := true
 	params := setupRequest{
 		Admin: &kolide.UserPayload{
 			Admin:    &t,
-			Username: &email,
+			Username: &username,
 			Email:    &email,
 			Password: &password,
 		},


### PR DESCRIPTION
Username continues to default to email if not specified in the options.

Closes #1970