### PR TITLE
Add 'get hosts' command to fleetctl

### DIFF
--- a/cmd/fleetctl/fleetctl.go
+++ b/cmd/fleetctl/fleetctl.go
@@ -36,6 +36,7 @@ func main() {
 				getPacksCommand(),
 				getLabelsCommand(),
 				getOptionsCommand(),
+				getHostsCommand(),
 				getEnrollSecretCommand(),
 			},
 		},

--- a/cmd/fleetctl/get.go
+++ b/cmd/fleetctl/get.go
@@ -326,7 +326,7 @@ func getHostsCommand() cli.Command {
 
 			for _, host := range hosts {
 				data = append(data, []string{
-					host.Host.UUID, // not sure if this is the most appropriate value to display as the 'id'
+					host.Host.UUID,
 					host.DisplayText,
 					host.Host.Platform,
 					host.Status,
@@ -334,7 +334,7 @@ func getHostsCommand() cli.Command {
 			}
 
 			table := defaultTable()
-			table.SetHeader([]string{"id", "hostname", "platform", "status"})
+			table.SetHeader([]string{"uuid", "hostname", "platform", "status"})
 			table.AppendBulk(data)
 			table.Render()
 

--- a/cmd/fleetctl/get.go
+++ b/cmd/fleetctl/get.go
@@ -296,3 +296,49 @@ func getEnrollSecretCommand() cli.Command {
 		},
 	}
 }
+
+func getHostsCommand() cli.Command {
+	return cli.Command{
+		Name:    "hosts",
+		Aliases: []string{"host", "h"},
+		Usage:   "List information about one or more hosts",
+		Flags: []cli.Flag{
+			configFlag(),
+			contextFlag(),
+		},
+		Action: func(c *cli.Context) error {
+			fleet, err := clientFromCLI(c)
+			if err != nil {
+				return err
+			}
+
+			hosts, err := fleet.GetHosts()
+			if err != nil {
+				return errors.Wrap(err, "could not list hosts")
+			}
+
+			if len(hosts) == 0 {
+				fmt.Println("no hosts found")
+				return nil
+			}
+
+			data := [][]string{}
+
+			for _, host := range hosts {
+				data = append(data, []string{
+					host.Host.UUID, // not sure if this is the most appropriate value to display as the 'id'
+					host.DisplayText,
+					host.Host.Platform,
+					host.Status,
+				})
+			}
+
+			table := defaultTable()
+			table.SetHeader([]string{"id", "hostname", "platform", "status"})
+			table.AppendBulk(data)
+			table.Render()
+
+			return nil
+		},
+	}
+}

--- a/server/service/client_hosts.go
+++ b/server/service/client_hosts.go
@@ -1,0 +1,35 @@
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+// GetHosts retrieves the list of all Hosts
+func (c *Client) GetHosts() ([]hostResponse, error) {
+	response, err := c.AuthenticatedDo("GET", "/api/v1/kolide/hosts", nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "GET /api/v1/kolide/hosts")
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, errors.Errorf(
+			"get hosts received status %d %s",
+			response.StatusCode,
+			extractServerErrorText(response.Body),
+		)
+	}
+	var responseBody listHostsResponse
+	err = json.NewDecoder(response.Body).Decode(&responseBody)
+	if err != nil {
+		return nil, errors.Wrap(err, "decode list hosts response")
+	}
+	if responseBody.Err != nil {
+		return nil, errors.Errorf("list hosts: %s", responseBody.Err)
+	}
+
+	return responseBody.Hosts, nil
+}


### PR DESCRIPTION
This commit:
 - adds a new subcommand for fetching hosts to `fleetctl get` command.

Why?
 - this allows for listing of all hosts via the fleetctl interface.
 There may be additional attributes of the host that we'd like to
 display, but this should be a good start.

Closes #1962