### PR TITLE
Default scheduled query name if not specified

### DIFF
--- a/server/datastore/datastore_packs_test.go
+++ b/server/datastore/datastore_packs_test.go
@@ -265,6 +265,32 @@ func testApplyPackSpecMissingQueries(t *testing.T, ds kolide.Datastore) {
 	}
 }
 
+func testApplyPackSpecMissingName(t *testing.T, ds kolide.Datastore) {
+	setupPackSpecsTest(t, ds)
+
+	specs := []*kolide.PackSpec{
+		&kolide.PackSpec{
+			Name: "test2",
+			Targets: kolide.PackSpecTargets{
+				Labels: []string{},
+			},
+			Queries: []kolide.PackSpecQuery{
+				kolide.PackSpecQuery{
+					QueryName: "foo",
+					Interval:  600,
+				},
+			},
+		},
+	}
+	err := ds.ApplyPackSpecs(specs)
+	require.NoError(t, err)
+
+	// Query name should have been copied into name field
+	spec, err := ds.GetPackSpec("test2")
+	require.NoError(t, err)
+	assert.Equal(t, "foo", spec.Queries[0].Name)
+}
+
 func testListLabelsForPack(t *testing.T, ds kolide.Datastore) {
 	labelSpecs := []*kolide.LabelSpec{
 		&kolide.LabelSpec{

--- a/server/datastore/datastore_test.go
+++ b/server/datastore/datastore_test.go
@@ -86,6 +86,7 @@ var testFunctions = [...]func(*testing.T, kolide.Datastore){
 	testApplyQueries,
 	testApplyPackSpecRoundtrip,
 	testApplyPackSpecMissingQueries,
+	testApplyPackSpecMissingName,
 	testGetPackSpec,
 	testApplyLabelSpecsRoundtrip,
 	testGetLabelSpec,

--- a/server/datastore/mysql/packs.go
+++ b/server/datastore/mysql/packs.go
@@ -74,6 +74,10 @@ func applyPackSpec(tx *sqlx.Tx, spec *kolide.PackSpec) error {
 
 	// Insert new scheduled queries for pack
 	for _, q := range spec.Queries {
+		// Default to query name if scheduled query name is not specified.
+		if q.Name == "" {
+			q.Name = q.QueryName
+		}
 		query = `
 			INSERT INTO scheduled_queries (
 				pack_id, query_name, name, description, ` + "`interval`" + `,


### PR DESCRIPTION
Brings the behavior of the server in line with the documentation, by using the
query name if the scheduled query name is not specified in a pack spec.

Closes #1990