### PR TITLE
`config_tls_refresh` => `config_refresh` in docs

### DIFF
--- a/docs/infrastructure/adding-hosts-to-fleet.md
+++ b/docs/infrastructure/adding-hosts-to-fleet.md
@@ -93,7 +93,7 @@ sudo osqueryd \
  --enroll_tls_endpoint=/api/v1/osquery/enroll \
  --config_plugin=tls \
  --config_tls_endpoint=/api/v1/osquery/config \
- --config_tls_refresh=10 \
+ --config_refresh=10 \
  --disable_distributed=false \
  --distributed_plugin=tls \
  --distributed_interval=10 \

--- a/docs/infrastructure/fleet-on-centos.md
+++ b/docs/infrastructure/fleet-on-centos.md
@@ -189,7 +189,7 @@ sudo /usr/bin/osqueryd \
   --enroll_tls_endpoint=/api/v1/osquery/enroll \
   --config_plugin=tls \
   --config_tls_endpoint=/api/v1/osquery/config \
-  --config_tls_refresh=10 \
+  --config_refresh=10 \
   --disable_distributed=false \
   --distributed_plugin=tls \
   --distributed_interval=3 \

--- a/docs/infrastructure/fleet-on-ubuntu.md
+++ b/docs/infrastructure/fleet-on-ubuntu.md
@@ -159,7 +159,7 @@ sudo /usr/bin/osqueryd \
   --enroll_tls_endpoint=/api/v1/osquery/enroll \
   --config_plugin=tls \
   --config_tls_endpoint=/api/v1/osquery/config \
-  --config_tls_refresh=10 \
+  --config_refresh=10 \
   --disable_distributed=false \
   --distributed_plugin=tls \
   --distributed_interval=3 \

--- a/tools/mac/config.mk
+++ b/tools/mac/config.mk
@@ -25,7 +25,7 @@ define KOLIDE_FLAGS
 
 --config_plugin=tls
 --config_tls_endpoint=/api/v1/osquery/config
---config_tls_refresh=10
+--config_refresh=10
 
 --disable_distributed=false
 --distributed_plugin=tls

--- a/tools/osquery/example_osquery.flags
+++ b/tools/osquery/example_osquery.flags
@@ -12,7 +12,7 @@
 
 --config_plugin=tls
 --config_tls_endpoint=/api/v1/osquery/config
---config_tls_refresh=10
+--config_refresh=10
 
 --disable_distributed=false
 --distributed_plugin=tls


### PR DESCRIPTION
Documentation has a typo. The field is `config_refresh`.