### PR TITLE
Tooltip for Add User button indicating why it is disabled

### DIFF
--- a/frontend/pages/Admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/Admin/UserManagementPage/UserManagementPage.jsx
@@ -291,6 +291,7 @@ export class UserManagementPage extends Component {
               className={`${baseClass}__add-user-btn`}
               disabled={!config.configured}
               onClick={toggleInviteUserModal}
+              title={config.configured ? 'Add User' : 'Email must be configured to add users'}
             >
               Add User
             </Button>


### PR DESCRIPTION
Help to alleviate common confusion for admins wondering why they can't add users.