### PR TITLE
Cleanup incoming hosts that do not complete enrollment

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -140,6 +140,7 @@ the way that the Fleet server works.
 				ticker := time.NewTicker(1 * time.Hour)
 				for {
 					ds.CleanupDistributedQueryCampaigns(time.Now())
+					ds.CleanupIncomingHosts(time.Now())
 					<-ticker.C
 				}
 			}()

--- a/server/datastore/datastore_test.go
+++ b/server/datastore/datastore_test.go
@@ -70,6 +70,7 @@ var testFunctions = [...]func(*testing.T, kolide.Datastore){
 	testAddLabelToPackTwice,
 	testGenerateHostStatusStatistics,
 	testMarkHostSeen,
+	testCleanupIncomingHosts,
 	testDuplicateNewQuery,
 	testIdempotentDeleteHost,
 	testChangeEmail,

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -317,6 +317,19 @@ func (d *Datastore) ListHosts(opt kolide.ListOptions) ([]*kolide.Host, error) {
 	return hosts, nil
 }
 
+func (d *Datastore) CleanupIncomingHosts(now time.Time) error {
+	sqlStatement := `
+		DELETE FROM hosts
+		WHERE host_name = '' AND osquery_version = ''
+		AND created_at < (? - INTERVAL 5 MINUTE)
+	`
+	if _, err := d.db.Exec(sqlStatement, now); err != nil {
+		return errors.Wrap(err, "cleanup incoming hosts")
+	}
+
+	return nil
+}
+
 func (d *Datastore) GenerateHostStatusStatistics(now time.Time) (online, offline, mia, new uint, e error) {
 	// The logic in this function should remain synchronized with
 	// host.Status and CountHostsInTargets

--- a/server/kolide/hosts.go
+++ b/server/kolide/hosts.go
@@ -43,6 +43,14 @@ type HostStore interface {
 	AuthenticateHost(nodeKey string) (*Host, error)
 	MarkHostSeen(host *Host, t time.Time) error
 	SearchHosts(query string, omit ...uint) ([]*Host, error)
+	// CleanupIncomingHosts deletes hosts that have enrolled but never
+	// updated their status details. This clears dead "incoming hosts" that
+	// never complete their registration.
+	//
+	// A host is considered incoming if both the hostname and
+	// osquery_version fields are empty. This means that multiple different
+	// osquery queries failed to populate details.
+	CleanupIncomingHosts(now time.Time) error
 	// GenerateHostStatusStatistics retrieves the count of online, offline,
 	// MIA and new hosts.
 	GenerateHostStatusStatistics(now time.Time) (online, offline, mia, new uint, err error)

--- a/server/mock/datastore_hosts.go
+++ b/server/mock/datastore_hosts.go
@@ -26,6 +26,8 @@ type AuthenticateHostFunc func(nodeKey string) (*kolide.Host, error)
 
 type MarkHostSeenFunc func(host *kolide.Host, t time.Time) error
 
+type CleanupIncomingHostsFunc func(t time.Time) error
+
 type SearchHostsFunc func(query string, omit ...uint) ([]*kolide.Host, error)
 
 type GenerateHostStatusStatisticsFunc func(now time.Time) (online uint, offline uint, mia uint, new uint, err error)
@@ -58,6 +60,9 @@ type HostStore struct {
 
 	MarkHostSeenFunc        MarkHostSeenFunc
 	MarkHostSeenFuncInvoked bool
+
+	CleanupIncomingHostsFunc        CleanupIncomingHostsFunc
+	CleanupIncomingHostsFuncInvoked bool
 
 	SearchHostsFunc        SearchHostsFunc
 	SearchHostsFuncInvoked bool
@@ -110,6 +115,11 @@ func (s *HostStore) AuthenticateHost(nodeKey string) (*kolide.Host, error) {
 func (s *HostStore) MarkHostSeen(host *kolide.Host, t time.Time) error {
 	s.MarkHostSeenFuncInvoked = true
 	return s.MarkHostSeenFunc(host, t)
+}
+
+func (s *HostStore) CleanupIncomingHosts(t time.Time) error {
+	s.CleanupIncomingHostsFuncInvoked = true
+	return s.CleanupIncomingHostsFunc(t)
 }
 
 func (s *HostStore) SearchHosts(query string, omit ...uint) ([]*kolide.Host, error) {


### PR DESCRIPTION
Deletes hosts that have enrolled but never updated their details (these
hosts show up as "incoming host" in the UI).

Closes #1438