### PR TITLE
Fix newlines in log output

### DIFF
--- a/server/logging/filesystem.go
+++ b/server/logging/filesystem.go
@@ -61,6 +61,8 @@ type flusher interface {
 // Write writes the provided logs to the filesystem
 func (l *filesystemLogWriter) Write(logs []json.RawMessage) error {
 	for _, log := range logs {
+		// Add newline to separate logs in output file
+		log = append(log, '\n')
 		if _, err := l.writer.Write(log); err != nil {
 			return errors.Wrap(err, "writing log")
 		}

--- a/server/logging/firehose.go
+++ b/server/logging/firehose.go
@@ -75,6 +75,10 @@ func (f *firehoseLogWriter) Write(logs []json.RawMessage) error {
 	var records []*firehose.Record
 	totalBytes := 0
 	for _, log := range logs {
+		// Add newline because Firehose does not output each record on
+		// a separate line.
+		log = append(log, '\n')
+
 		// We don't really have a good option for what to do with logs
 		// that are too big for Firehose. This behavior is consistent
 		// with osquery's behavior in the Firehose logger plugin, and

--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -191,9 +191,6 @@ func (svc service) GetClientConfig(ctx context.Context) (map[string]interface{},
 }
 
 func (svc service) SubmitStatusLogs(ctx context.Context, logs []json.RawMessage) error {
-	for _, log := range logs {
-		log = append(log, '\n')
-	}
 	if err := svc.osqueryLogWriter.Status.Write(logs); err != nil {
 		return osqueryError{message: "error writing status logs: " + err.Error()}
 	}
@@ -201,9 +198,6 @@ func (svc service) SubmitStatusLogs(ctx context.Context, logs []json.RawMessage)
 }
 
 func (svc service) SubmitResultLogs(ctx context.Context, logs []json.RawMessage) error {
-	for _, log := range logs {
-		log = append(log, '\n')
-	}
 	if err := svc.osqueryLogWriter.Result.Write(logs); err != nil {
 		return osqueryError{message: "error writing result logs: " + err.Error()}
 	}

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -46,5 +46,5 @@ func TestRotateLoggerSIGHUP(t *testing.T) {
 	logMsg, err := ioutil.ReadFile(f.Name())
 	require.Nil(t, err)
 
-	require.Equal(t, "msg2", string(logMsg))
+	require.Equal(t, "msg2\n", string(logMsg))
 }


### PR DESCRIPTION
Fixes a regression introduced in 2.1.0 in which separate log lines are
no longer output separated by a newline. Now log lines in both output
plugins will do so.