### PR TITLE
Run correct query when navigating to query by URL

### DIFF
--- a/frontend/pages/queries/QueryPage/QueryPage.jsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.jsx
@@ -108,6 +108,10 @@ export class QueryPage extends Component {
       this.resetCampaignAndTargets();
     }
 
+    if (nextProps.query) {
+      this.setState({ queryText: nextProps.query.query });
+    }
+
     if (!isEqual(selectedHosts, this.props.selectedHosts)) {
       helpers.selectHosts(dispatch, {
         hosts: selectedHosts,


### PR DESCRIPTION
Fixes a bug in which the default query would run rather than the query
displayed in the editor unless that query was manually edited after the
page loaded.

Fixes #2028