### PR TITLE
Disable editing of logged in user email in admin panel

### DIFF
--- a/frontend/components/UserBlock/UserBlock.jsx
+++ b/frontend/components/UserBlock/UserBlock.jsx
@@ -65,7 +65,7 @@ class UserBlock extends Component {
   }
 
   render () {
-    const { isEditing, isInvite, user, userErrors } = this.props;
+    const { isEditing, isInvite, user, userErrors, isCurrentUser } = this.props;
     const {
       admin,
       email,
@@ -131,6 +131,7 @@ class UserBlock extends Component {
       return (
         <div className={userWrapperClass}>
           <EditUserForm
+            isCurrentUser={isCurrentUser}
             onCancel={onToggleEditing}
             handleSubmit={onEditUser}
             formData={user}

--- a/frontend/components/forms/admin/EditUserForm/EditUserForm.jsx
+++ b/frontend/components/forms/admin/EditUserForm/EditUserForm.jsx
@@ -11,6 +11,7 @@ const fieldNames = ['email', 'name', 'position', 'username', 'sso_enabled'];
 
 class EditUserForm extends Component {
   static propTypes = {
+    isCurrentUser: PropTypes.bool.isRequired,
     onCancel: PropTypes.func,
     handleSubmit: PropTypes.func,
     fields: PropTypes.shape({
@@ -23,7 +24,7 @@ class EditUserForm extends Component {
   };
 
   render () {
-    const { fields, handleSubmit, onCancel } = this.props;
+    const { fields, handleSubmit, onCancel, isCurrentUser } = this.props;
 
     return (
       <form className={baseClass} onSubmit={handleSubmit}>
@@ -52,6 +53,7 @@ class EditUserForm extends Component {
           {...fields.email}
           inputWrapperClass={`${baseClass}__input-wrap`}
           label="Email"
+          disabled={isCurrentUser}
           labelClassName={`${baseClass}__label`}
           inputClassName={`${baseClass}__input ${baseClass}__input--email`}
         />


### PR DESCRIPTION
Doing so has long resulted in an error when submitting the form. This
disables the input field when editing the logged in users details in the
admin panel.

The logged in user can still change their own email using the "Account
Settings" page accessed in the top left of the sidebar.