### PR TITLE
Update logic for setting primary NIC

### DIFF
--- a/server/kolide/hosts_test.go
+++ b/server/kolide/hosts_test.go
@@ -8,40 +8,122 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestResetHosts(t *testing.T) {
+func TestResetPrimaryNetworkNoInterfaces(t *testing.T) {
 	host := Host{}
 	result := host.ResetPrimaryNetwork()
 	assert.False(t, result)
+	assert.Nil(t, host.PrimaryNetworkInterfaceID)
+}
 
-	host.NetworkInterfaces = []*NetworkInterface{
-		&NetworkInterface{
-			ID:        1,
-			IPAddress: "192.168.1.2",
-		},
-		&NetworkInterface{
-			ID:        2,
-			IPAddress: "192.168.1.3",
-		},
-	}
-
-	result = host.ResetPrimaryNetwork()
-	assert.True(t, result)
-	assert.Equal(t, uint(1), *host.PrimaryNetworkInterfaceID)
-
-	host.PrimaryNetworkInterfaceID = &host.NetworkInterfaces[1].ID
-	result = host.ResetPrimaryNetwork()
-	assert.False(t, result)
-	assert.Equal(t, uint(2), *host.PrimaryNetworkInterfaceID)
-
-	host.NetworkInterfaces = host.NetworkInterfaces[:1]
-	result = host.ResetPrimaryNetwork()
-	assert.True(t, result)
-	assert.Equal(t, uint(1), *host.PrimaryNetworkInterfaceID)
-
-	host.NetworkInterfaces = []*NetworkInterface{}
-	result = host.ResetPrimaryNetwork()
+func TestResetPrimaryNetworkInterfaceRemoved(t *testing.T) {
+	// Start with interface set, but then all interfaces are removed
+	id := uint(1)
+	host := Host{PrimaryNetworkInterfaceID: &id}
+	result := host.ResetPrimaryNetwork()
 	assert.True(t, result)
 	assert.Nil(t, host.PrimaryNetworkInterfaceID)
+}
+
+func TestResetPrimaryNetworkInterfaceNew(t *testing.T) {
+	host := Host{
+		NetworkInterfaces: []*NetworkInterface{
+			&NetworkInterface{
+				ID:        1,
+				IPAddress: "192.168.1.2",
+			},
+			&NetworkInterface{
+				ID:        2,
+				IPAddress: "192.168.1.3",
+			},
+		},
+	}
+	result := host.ResetPrimaryNetwork()
+	assert.True(t, result)
+	assert.Equal(t, uint(1), *host.PrimaryNetworkInterfaceID)
+}
+
+func TestResetPrimaryNetworkInterfaceUnchanged(t *testing.T) {
+	id := uint(1)
+	host := Host{
+		NetworkInterfaces: []*NetworkInterface{
+			&NetworkInterface{
+				ID:        1,
+				IPAddress: "192.168.1.2",
+			},
+			&NetworkInterface{
+				ID:        2,
+				IPAddress: "192.168.1.3",
+			},
+		},
+		PrimaryNetworkInterfaceID: &id,
+	}
+	result := host.ResetPrimaryNetwork()
+	assert.False(t, result)
+	assert.Equal(t, uint(1), *host.PrimaryNetworkInterfaceID)
+}
+
+func TestResetPrimaryNetworkInterfaceChanged(t *testing.T) {
+	id := uint(1)
+	host := Host{
+		NetworkInterfaces: []*NetworkInterface{
+			// 2 appears before 1 now (meaning more traffic to that
+			// interface)
+			&NetworkInterface{
+				ID:        2,
+				IPAddress: "192.168.1.3",
+			},
+			&NetworkInterface{
+				ID:        1,
+				IPAddress: "192.168.1.2",
+			},
+		},
+		PrimaryNetworkInterfaceID: &id,
+	}
+	result := host.ResetPrimaryNetwork()
+	assert.True(t, result)
+	assert.Equal(t, uint(2), *host.PrimaryNetworkInterfaceID)
+}
+
+func TestResetPrimaryNetworkLinkLocal(t *testing.T) {
+	id := uint(1)
+	host := Host{
+		NetworkInterfaces: []*NetworkInterface{
+			&NetworkInterface{
+				ID: 1,
+				// Link-local IP
+				IPAddress: "169.254.10.12",
+			},
+			&NetworkInterface{
+				ID:        2,
+				IPAddress: "192.168.1.2",
+			},
+		},
+		PrimaryNetworkInterfaceID: &id,
+	}
+	result := host.ResetPrimaryNetwork()
+	assert.True(t, result)
+	assert.Equal(t, uint(2), *host.PrimaryNetworkInterfaceID)
+}
+
+func TestResetPrimaryNetworkLoopback(t *testing.T) {
+	id := uint(1)
+	host := Host{
+		NetworkInterfaces: []*NetworkInterface{
+			&NetworkInterface{
+				ID: 1,
+				// Loopback IP
+				IPAddress: "127.0.0.1",
+			},
+			&NetworkInterface{
+				ID:        2,
+				IPAddress: "192.168.1.2",
+			},
+		},
+		PrimaryNetworkInterfaceID: &id,
+	}
+	result := host.ResetPrimaryNetwork()
+	assert.True(t, result)
+	assert.Equal(t, uint(2), *host.PrimaryNetworkInterfaceID)
 }
 
 func TestHostStatus(t *testing.T) {


### PR DESCRIPTION
- The most active NIC will be picked even if a formerly more active
  interface still exists (previously, a NIC would stay primary as long
  as it existed).
- Ignore link-local and loopback interfaces when choosing the primary.
- Fix bugs in which update status of the primary interface could be
  reported incorrectly.

Fixes #2020