### PR TITLE
Save details provided by host during enrollment

### DIFF
--- a/server/kolide/osquery.go
+++ b/server/kolide/osquery.go
@@ -6,7 +6,7 @@ import (
 )
 
 type OsqueryService interface {
-	EnrollAgent(ctx context.Context, enrollSecret, hostIdentifier string) (nodeKey string, err error)
+	EnrollAgent(ctx context.Context, enrollSecret, hostIdentifier string, hostDetails map[string](map[string]string)) (nodeKey string, err error)
 	AuthenticateHost(ctx context.Context, nodeKey string) (host *Host, err error)
 	GetClientConfig(ctx context.Context) (config map[string]interface{}, err error)
 	// GetDistributedQueries retrieves the distributed queries to run for

--- a/server/launcher/launcher.go
+++ b/server/launcher/launcher.go
@@ -23,7 +23,7 @@ type launcherWrapper struct {
 }
 
 func (svc *launcherWrapper) RequestEnrollment(ctx context.Context, enrollSecret, hostIdentifier string) (string, bool, error) {
-	nodeKey, err := svc.tls.EnrollAgent(ctx, enrollSecret, hostIdentifier)
+	nodeKey, err := svc.tls.EnrollAgent(ctx, enrollSecret, hostIdentifier, map[string](map[string]string){})
 	if err != nil {
 		if authErr, ok := err.(nodeInvalidErr); ok {
 			return "", authErr.NodeInvalid(), err

--- a/server/launcher/launcher_test.go
+++ b/server/launcher/launcher_test.go
@@ -106,6 +106,7 @@ func newTLSService(t *testing.T) *mock.TLSService {
 			ctx context.Context,
 			enrollSecret string,
 			hostIdentifier string,
+			hostDetails map[string](map[string]string),
 		) (nodeKey string, err error) {
 			nodeKey = "noop"
 			return

--- a/server/mock/service_osquery.go
+++ b/server/mock/service_osquery.go
@@ -11,7 +11,7 @@ import (
 
 var _ kolide.OsqueryService = (*TLSService)(nil)
 
-type EnrollAgentFunc func(ctx context.Context, enrollSecret string, hostIdentifier string) (nodeKey string, err error)
+type EnrollAgentFunc func(ctx context.Context, enrollSecret string, hostIdentifier string, hostDetails map[string](map[string]string)) (nodeKey string, err error)
 
 type AuthenticateHostFuncI func(ctx context.Context, nodeKey string) (host *kolide.Host, err error)
 
@@ -48,9 +48,9 @@ type TLSService struct {
 	SubmitResultLogsFuncInvoked bool
 }
 
-func (s *TLSService) EnrollAgent(ctx context.Context, enrollSecret string, hostIdentifier string) (nodeKey string, err error) {
+func (s *TLSService) EnrollAgent(ctx context.Context, enrollSecret string, hostIdentifier string, hostDetails map[string](map[string]string)) (nodeKey string, err error) {
 	s.EnrollAgentFuncInvoked = true
-	return s.EnrollAgentFunc(ctx, enrollSecret, hostIdentifier)
+	return s.EnrollAgentFunc(ctx, enrollSecret, hostIdentifier, hostDetails)
 }
 
 func (s *TLSService) AuthenticateHost(ctx context.Context, nodeKey string) (host *kolide.Host, err error) {

--- a/server/service/endpoint_middleware_test.go
+++ b/server/service/endpoint_middleware_test.go
@@ -212,7 +212,7 @@ func TestAuthenticatedHost(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	goodNodeKey, err := svc.EnrollAgent(ctx, "foobarbaz", "host123")
+	goodNodeKey, err := svc.EnrollAgent(ctx, "foobarbaz", "host123", nil)
 	assert.Nil(t, err)
 	require.NotEmpty(t, goodNodeKey)
 

--- a/server/service/endpoint_osquery.go
+++ b/server/service/endpoint_osquery.go
@@ -13,8 +13,9 @@ import (
 ////////////////////////////////////////////////////////////////////////////////
 
 type enrollAgentRequest struct {
-	EnrollSecret   string `json:"enroll_secret"`
-	HostIdentifier string `json:"host_identifier"`
+	EnrollSecret   string                         `json:"enroll_secret"`
+	HostIdentifier string                         `json:"host_identifier"`
+	HostDetails    map[string](map[string]string) `json:"host_details"`
 }
 
 type enrollAgentResponse struct {
@@ -27,7 +28,7 @@ func (r enrollAgentResponse) error() error { return r.Err }
 func makeEnrollAgentEndpoint(svc kolide.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(enrollAgentRequest)
-		nodeKey, err := svc.EnrollAgent(ctx, req.EnrollSecret, req.HostIdentifier)
+		nodeKey, err := svc.EnrollAgent(ctx, req.EnrollSecret, req.HostIdentifier, req.HostDetails)
 		if err != nil {
 			return enrollAgentResponse{Err: err}, nil
 		}

--- a/server/service/logging_osquery.go
+++ b/server/service/logging_osquery.go
@@ -10,7 +10,7 @@ import (
 	"github.com/kolide/fleet/server/kolide"
 )
 
-func (mw loggingMiddleware) EnrollAgent(ctx context.Context, enrollSecret string, hostIdentifier string) (string, error) {
+func (mw loggingMiddleware) EnrollAgent(ctx context.Context, enrollSecret string, hostIdentifier string, hostDetails map[string](map[string]string)) (string, error) {
 	var (
 		nodeKey string
 		err     error
@@ -25,7 +25,7 @@ func (mw loggingMiddleware) EnrollAgent(ctx context.Context, enrollSecret string
 		)
 	}(time.Now())
 
-	nodeKey, err = mw.Service.EnrollAgent(ctx, enrollSecret, hostIdentifier)
+	nodeKey, err = mw.Service.EnrollAgent(ctx, enrollSecret, hostIdentifier, hostDetails)
 	return nodeKey, err
 }
 


### PR DESCRIPTION
When an osqueryd agent sends an enroll request it automatically sends
some details about the system. We now save these details which helps
ensure we send the correct platform config.

Closes #2065