### PR TITLE
Fix target search behavior with - and + symbols

### DIFF
--- a/server/datastore/mysql/fulltext.go
+++ b/server/datastore/mysql/fulltext.go
@@ -1,0 +1,30 @@
+package mysql
+
+import (
+	"regexp"
+	"strings"
+)
+
+var mysqlFTSSymbolRegexp = regexp.MustCompile("[-+]+")
+
+func queryMinLength(query string) bool {
+	return countLongestTerm(query) >= 3
+}
+
+func countLongestTerm(query string) int {
+	max := 0
+	for _, q := range strings.Split(query, " ") {
+		if len(q) > max {
+			max = len(q)
+		}
+	}
+	return max
+}
+
+// transformQuery replaces occurrences of characters that are treated specially
+// by the MySQL FTS engine to try to make the search more user-friendly
+func transformQuery(query string) string {
+	return strings.TrimSpace(
+		mysqlFTSSymbolRegexp.ReplaceAllLiteralString(query, " "),
+	) + "*"
+}

--- a/server/datastore/mysql/fulltext_test.go
+++ b/server/datastore/mysql/fulltext_test.go
@@ -1,0 +1,44 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransformQuery(t *testing.T) {
+	testCases := []struct {
+		in  string
+		out string
+	}{
+		{"foobar", "foobar*"},
+		{"tim tom", "tim tom*"},
+		{"f%5", "f%5*"},
+		{"f-o-o-b-a-r", "f o o b a r*"},
+		{"f-o+o-b--+a-r+", "f o o b a r*"},
+	}
+
+	for _, tt := range testCases {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, tt.out, transformQuery(tt.in))
+		})
+	}
+}
+
+func TestQueryMinLength(t *testing.T) {
+	testCases := []struct {
+		in  string
+		out bool
+	}{
+		{"a b c d", false},
+		{"foobar", true},
+		{"a foo fim b", true},
+		{"a fo fi b*", false},
+	}
+
+	for _, tt := range testCases {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, tt.out, queryMinLength(tt.in))
+		})
+	}
+}

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -540,11 +540,7 @@ func (d *Datastore) MarkHostSeen(host *kolide.Host, t time.Time) error {
 }
 
 func (d *Datastore) searchHostsWithOmits(query string, omit ...uint) ([]*kolide.Host, error) {
-	hostnameQuery := query
-	if len(hostnameQuery) > 0 {
-		hostnameQuery += "*"
-	}
-
+	hostnameQuery := transformQuery(query)
 	ipQuery := `"` + query + `"`
 
 	sqlStatement :=
@@ -630,15 +626,13 @@ func (d *Datastore) searchHostsDefault(omit ...uint) ([]*kolide.Host, error) {
 // SearchHosts find hosts by query containing an IP address or a host name. Optionally
 // pass a list of IDs to omit from the search
 func (d *Datastore) SearchHosts(query string, omit ...uint) ([]*kolide.Host, error) {
-	if query == "" {
+	hostnameQuery := transformQuery(query)
+	if !queryMinLength(hostnameQuery) {
 		return d.searchHostsDefault(omit...)
 	}
 	if len(omit) > 0 {
 		return d.searchHostsWithOmits(query, omit...)
 	}
-
-	hostnameQuery := query
-	hostnameQuery += "*"
 
 	// Needs quotes to avoid each . marking a word boundary
 	ipQuery := `"` + query + `"`


### PR DESCRIPTION
This PR makes the target search more user-friendly by stripping symbols that
have a special interpretation in MySQL FTS.

Closes #2017