### PR TITLE
Update changelog for 2.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Kolide Fleet 2.1.2 (May 30, 2019)
+
+* Prevent sending of SMTP credentials over insecure connection
+
+* Prefix generated SAML IDs with 'id' (improves compatibility with some IdPs)
+
 ## Kolide Fleet 2.1.1 (Apr 25, 2019)
 
 * Automatically pull AWS STS credentials for Firehose logging if they are not specified in config.


### PR DESCRIPTION
This is coming well after the release because the changelog was
included in the release page on Github but not in the repo.