### PR TITLE
Use Github hosted assets in emails sent by Fleet

### DIFF
--- a/server/kolide/emails.go
+++ b/server/kolide/emails.go
@@ -49,7 +49,8 @@ type PasswordResetRequest struct {
 // SMTPTestMailer is used to build an email message that will be used as
 // a test message when testing SMTP configuration
 type SMTPTestMailer struct {
-	KolideServerURL string
+	KolideServerURL template.URL
+	AssetURL        template.URL
 }
 
 func (m *SMTPTestMailer) Message() ([]byte, error) {
@@ -69,6 +70,8 @@ func (m *SMTPTestMailer) Message() ([]byte, error) {
 type PasswordResetMailer struct {
 	// URL for the Fleet application
 	KolideServerURL template.URL
+	// URL for loading image assets
+	AssetURL template.URL
 	// Token password reset token
 	Token string
 }

--- a/server/kolide/invites.go
+++ b/server/kolide/invites.go
@@ -76,6 +76,7 @@ type Invite struct {
 type InviteMailer struct {
 	*Invite
 	KolideServerURL   template.URL
+	AssetURL          template.URL
 	InvitedByUsername string
 	OrgName           string
 }

--- a/server/kolide/users.go
+++ b/server/kolide/users.go
@@ -195,6 +195,7 @@ func falseIfNil(b *bool) bool {
 
 type ChangeEmailMailer struct {
 	KolideServerURL template.URL
+	AssetURL        template.URL
 	Token           string
 }
 

--- a/server/mail/templates/change_email_confirmation.html
+++ b/server/mail/templates/change_email_confirmation.html
@@ -47,7 +47,7 @@
           <table width="580" align="center" cellpadding="0" cellspacing="0" bgcolor="#ffffff" style="margin: 20px 10px;">
             <tr>
               <td colspan="2" bgcolor="#ffffff" style="padding:20px; font-family: 'Oxygen', Arial, sans-serif;">
-                <img src="{{.KolideServerURL}}/assets/images/kolide-logo-color@2x.png" width="174" height="48" />
+                <img src="{{.AssetURL}}/assets/images/kolide-logo-color@2x.png?raw=true" width="174" height="48" />
               </td>
             </tr>
             <tr>
@@ -69,7 +69,7 @@
                 <a href="https://github.com/kolide/fleet/tree/master/docs" style="color: #fff; text-decoration: none;">Fleet Documentation</a>
               </td>
               <td valign="middle" align="right" style="padding:10px 20px; font-family: 'Oxygen', Arial, sans-serif;">
-                <a href="https://kolide.com" style="text-decoration: none;"><img src="{{.KolideServerURL}}/assets/images/kolide-white@2x.png" width="122" height="33" /></a>
+                <a href="https://kolide.com" style="text-decoration: none;"><img src="{{.AssetURL}}/assets/images/kolide-white@2x.png?raw=true" width="122" height="33" /></a>
               </td>
             </tr>
           </table>

--- a/server/mail/templates/invite_token.html
+++ b/server/mail/templates/invite_token.html
@@ -47,7 +47,7 @@
           <table width="580" align="center" cellpadding="0" cellspacing="0" bgcolor="#ffffff" style="margin: 20px 10px;">
             <tr>
               <td colspan="2" bgcolor="#ffffff" style="padding:20px; font-family: 'Oxygen', Arial, sans-serif;">
-                <img src="{{.KolideServerURL}}/assets/images/kolide-logo-color@2x.png" width="174" height="48" />
+                <img src="{{.AssetURL}}/assets/images/kolide-logo-color@2x.png?raw=true" width="174" height="48" />
               </td>
             </tr>
             <tr>
@@ -73,7 +73,7 @@
                 <a href="https://github.com/kolide/fleet/tree/master/docs" style="color: #fff; text-decoration: none;">Fleet Documentation</a>
               </td>
               <td valign="middle" align="right" style="padding:10px 20px; font-family: 'Oxygen', Arial, sans-serif;">
-                <a href="https://kolide.com" style="text-decoration: none;"><img src="{{.KolideServerURL}}/assets/images/kolide-white@2x.png" width="122" height="33" /></a>
+                <a href="https://kolide.com" style="text-decoration: none;"><img src="{{.AssetURL}}/assets/images/kolide-white@2x.png?raw=true" width="122" height="33" /></a>
               </td>
             </tr>
           </table>

--- a/server/mail/templates/password_reset.html
+++ b/server/mail/templates/password_reset.html
@@ -47,15 +47,15 @@
           <table width="580" align="center" cellpadding="0" cellspacing="0" bgcolor="#ffffff" style="margin: 20px 10px;">
             <tr>
               <td colspan="2" bgcolor="#ffffff" style="padding:20px; font-family: 'Oxygen', Arial, sans-serif;">
-                <img src="{{.KolideServerURL}}/assets/images/kolide-logo-color@2x.png" width="174" height="48" />
+                <img src="{{.AssetURL}}/assets/images/kolide-logo-color@2x.png?raw=true" width="174" height="48" />
               </td>
             </tr>
             <tr>
               <td colspan="2" style="padding:60px; font-family: 'Oxygen', Arial, sans-serif;">
-                <h1 style="font-weight:300">Reset Your Kolide Password...</h1>
-                <p>You, or someone pretending to be you, requested a password reset. Follow the link below to reset your password:</p>
+                <h1 style="font-weight:300">Reset Your Fleet Password...</h1>
+                <p>Someone requested a password reset on your Fleet account. Follow the link below to reset your password:</p>
                 <p><a href="{{.KolideServerURL}}/login/reset?token={{.Token}}">Reset Password</a></p>
-                <p style="color:#9ca3ac"><em>If you didn't make the request, then ignore this email, as no changes have been made.</em></p>
+                <p style="color:#9ca3ac"><em>If you did not make the request, you may ignore this email as no changes have been made.</em></p>
               </td>
             </tr>
             <tr bgcolor="#9ca3ac">
@@ -63,7 +63,7 @@
                 <a href="https://github.com/kolide/fleet/tree/master/docs" style="color: #fff; text-decoration: none;">Fleet Documentation</a>
               </td>
               <td valign="middle" align="right" style="padding:10px 20px; font-family: 'Oxygen', Arial, sans-serif;">
-                <a href="https://kolide.com" style="text-decoration: none;"><img src="{{.KolideServerURL}}/assets/images/kolide-white@2x.png" width="122" height="33" /></a>
+                <a href="https://kolide.com" style="text-decoration: none;"><img src="{{.AssetURL}}/assets/images/kolide-white@2x.png?raw=true" width="122" height="33" /></a>
               </td>
             </tr>
           </table>

--- a/server/mail/templates/smtp_setup.html
+++ b/server/mail/templates/smtp_setup.html
@@ -47,7 +47,7 @@
           <table width="580" align="center" cellpadding="0" cellspacing="0" bgcolor="#ffffff" style="margin: 20px 10px;">
             <tr>
               <td colspan="2" bgcolor="#ffffff" style="padding:20px; font-family: 'Oxygen', Arial, sans-serif;">
-                <img src="{{.KolideServerURL}}/assets/images/kolide-logo-color@2x.png" width="174" height="48" />
+                <img src="{{.AssetURL}}/assets/images/kolide-logo-color@2x.png?raw=true" width="174" height="48" />
               </td>
             </tr>
             <tr>
@@ -61,7 +61,7 @@
                 <a href="https://github.com/kolide/fleet/tree/master/docs" style="color: #fff; text-decoration: none;">Fleet Documentation</a>
               </td>
               <td valign="middle" align="right" style="padding:10px 20px; font-family: 'Oxygen', Arial, sans-serif;">
-                <a href="https://kolide.com" style="text-decoration: none;"><img src="{{.KolideServerURL}}/assets/images/kolide-white@2x.png" width="122" height="33" /></a>
+                <a href="https://kolide.com" style="text-decoration: none;"><img src="{{.AssetURL}}/assets/images/kolide-white@2x.png?raw=true" width="122" height="33" /></a>
               </td>
             </tr>
           </table>

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -3,7 +3,9 @@
 package service
 
 import (
+	"html/template"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/WatchBeam/clock"
@@ -12,6 +14,7 @@ import (
 	"github.com/kolide/fleet/server/kolide"
 	"github.com/kolide/fleet/server/logging"
 	"github.com/kolide/fleet/server/sso"
+	"github.com/kolide/kit/version"
 	"github.com/pkg/errors"
 )
 
@@ -69,4 +72,17 @@ type validationMiddleware struct {
 	kolide.Service
 	ds              kolide.Datastore
 	ssoSessionStore sso.SessionStore
+}
+
+// getAssetURL gets the URL prefix used for retrieving assets from Github. This
+// function will determine the appropriate version to use, and create a URL
+// prefix for retrieving assets from that tag.
+func getAssetURL() template.URL {
+	v := version.Version().Version
+	tag := strings.Split(v, "-")[0]
+	if tag == "unknown" {
+		tag = "master"
+	}
+
+	return template.URL("https://github.com/kolide/fleet/blob/" + tag)
 }

--- a/server/service/service_appconfig.go
+++ b/server/service/service_appconfig.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"html/template"
 	"strings"
 
 	"github.com/kolide/fleet/server/contexts/viewer"
@@ -64,7 +65,8 @@ func (svc service) SendTestEmail(ctx context.Context, config *kolide.AppConfig) 
 		Subject: "Hello from Fleet",
 		To:      []string{vc.User.Email},
 		Mailer: &kolide.SMTPTestMailer{
-			KolideServerURL: config.KolideServerURL,
+			KolideServerURL: template.URL(config.KolideServerURL),
+			AssetURL:        getAssetURL(),
 		},
 		Config: config,
 	}

--- a/server/service/service_invites.go
+++ b/server/service/service_invites.go
@@ -68,6 +68,7 @@ func (svc service) InviteNewUser(ctx context.Context, payload kolide.InvitePaylo
 		Mailer: &kolide.InviteMailer{
 			Invite:            invite,
 			KolideServerURL:   template.URL(config.KolideServerURL),
+			AssetURL:          getAssetURL(),
 			OrgName:           config.OrgName,
 			InvitedByUsername: invitedBy,
 		},

--- a/server/service/service_users.go
+++ b/server/service/service_users.go
@@ -155,6 +155,7 @@ func (svc service) modifyEmailAddress(ctx context.Context, user *kolide.User, em
 		Mailer: &kolide.ChangeEmailMailer{
 			Token:           token,
 			KolideServerURL: template.URL(config.KolideServerURL),
+			AssetURL:        getAssetURL(),
 		},
 	}
 	return svc.mailService.SendEmail(changeEmail)
@@ -355,6 +356,7 @@ func (svc service) RequestPasswordReset(ctx context.Context, email string) error
 		Config:  config,
 		Mailer: &kolide.PasswordResetMailer{
 			KolideServerURL: template.URL(config.KolideServerURL),
+			AssetURL:        getAssetURL(),
 			Token:           token,
 		},
 	}


### PR DESCRIPTION
This change allows the images in Fleet emails to load properly from any
device with connectivity to github.com. Previously, emails might try to
load resources from a Kolide server not accessible from the email
client.

The asset URL will be based on the most recent git tag to accomodate
backwards-compatibility if the assets in the repo change.

Closes #1471