### PR TITLE
Allow idp_name to be 4 characters

### DIFF
--- a/server/service/validation_app_config.go
+++ b/server/service/validation_app_config.go
@@ -52,8 +52,8 @@ func validateSSOSettings(p kolide.AppConfigPayload, existing *kolide.AppConfig, 
 					invalid.Append("idp_name", "required")
 				}
 			} else {
-				if len(*p.SSOSettings.IDPName) < 5 {
-					invalid.Append("idp_name", "must be 5 or more characters")
+				if len(*p.SSOSettings.IDPName) < 4 {
+					invalid.Append("idp_name", "must be 4 or more characters")
 				}
 			}
 		}


### PR DESCRIPTION
When setting up SAML, `idp_name` is currently hardcoded at ≥ 5 characters, which prevents setting "Okta" as an identity provider's name.