### PR TITLE
Allow host search by UUID

### DIFF
--- a/server/datastore/datastore_hosts_test.go
+++ b/server/datastore/datastore_hosts_test.go
@@ -305,7 +305,7 @@ func testSearchHosts(t *testing.T, ds kolide.Datastore) {
 		DetailUpdateTime: time.Now(),
 		SeenTime:         time.Now(),
 		NodeKey:          "3",
-		UUID:             "3",
+		UUID:             "abc-def-ghi",
 		HostName:         "foo-bar.local",
 	})
 	require.Nil(t, err)
@@ -328,6 +328,11 @@ func testSearchHosts(t *testing.T, ds kolide.Datastore) {
 	require.Nil(t, err)
 	require.Len(t, host, 1)
 	assert.Equal(t, "foo.local", host[0].HostName)
+
+	host, err = ds.SearchHosts("abc")
+	require.Nil(t, err)
+	require.Len(t, host, 1)
+	assert.Equal(t, "abc-def-ghi", host[0].UUID)
 
 	none, err := ds.SearchHosts("xxx")
 	assert.Nil(t, err)
@@ -456,7 +461,7 @@ func testDistributedQueriesForHost(t *testing.T, ds kolide.Datastore) {
 
 	// Add a target to the campaign
 	target := &kolide.DistributedQueryCampaignTarget{
-		Type: kolide.TargetLabel,
+		Type:                       kolide.TargetLabel,
 		DistributedQueryCampaignID: c1.ID,
 		TargetID:                   l1.ID,
 	}
@@ -475,9 +480,9 @@ func testDistributedQueriesForHost(t *testing.T, ds kolide.Datastore) {
 
 	// Record an execution
 	exec := &kolide.DistributedQueryExecution{
-		HostID: h1.ID,
+		HostID:                     h1.ID,
 		DistributedQueryCampaignID: c1.ID,
-		Status: kolide.ExecutionSucceeded,
+		Status:                     kolide.ExecutionSucceeded,
 	}
 	_, err = ds.NewDistributedQueryExecution(exec)
 	require.Nil(t, err)
@@ -500,7 +505,7 @@ func testDistributedQueriesForHost(t *testing.T, ds kolide.Datastore) {
 
 	// This one targets only h1
 	target = &kolide.DistributedQueryCampaignTarget{
-		Type: kolide.TargetHost,
+		Type:                       kolide.TargetHost,
 		DistributedQueryCampaignID: c2.ID,
 		TargetID:                   h1.ID,
 	}

--- a/server/datastore/inmem/hosts.go
+++ b/server/datastore/inmem/hosts.go
@@ -216,7 +216,7 @@ func (d *Datastore) SearchHosts(query string, omit ...uint) ([]*kolide.Host, err
 			break
 		}
 
-		if strings.Contains(h.HostName, query) && !omitLookup[h.ID] {
+		if (strings.Contains(h.HostName, query) || strings.Contains(h.UUID, query)) && !omitLookup[h.ID] {
 			results = append(results, h)
 			continue
 		}

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -540,7 +540,7 @@ func (d *Datastore) MarkHostSeen(host *kolide.Host, t time.Time) error {
 }
 
 func (d *Datastore) searchHostsWithOmits(query string, omit ...uint) ([]*kolide.Host, error) {
-	hostnameQuery := transformQuery(query)
+	hostQuery := transformQuery(query)
 	ipQuery := `"` + query + `"`
 
 	sqlStatement :=
@@ -553,7 +553,7 @@ func (d *Datastore) searchHostsWithOmits(query string, omit ...uint) ([]*kolide.
 				SELECT id
 				FROM hosts
 				WHERE
-				MATCH(host_name) AGAINST(? IN BOOLEAN MODE)
+				MATCH(host_name, uuid) AGAINST(? IN BOOLEAN MODE)
 			)
 		OR
 			id IN (
@@ -568,7 +568,7 @@ func (d *Datastore) searchHostsWithOmits(query string, omit ...uint) ([]*kolide.
 		LIMIT 10
 	`
 
-	sql, args, err := sqlx.In(sqlStatement, hostnameQuery, ipQuery, omit)
+	sql, args, err := sqlx.In(sqlStatement, hostQuery, ipQuery, omit)
 	if err != nil {
 		return nil, errors.Wrap(err, "searching hosts")
 	}
@@ -623,11 +623,11 @@ func (d *Datastore) searchHostsDefault(omit ...uint) ([]*kolide.Host, error) {
 	return hosts, nil
 }
 
-// SearchHosts find hosts by query containing an IP address or a host name. Optionally
-// pass a list of IDs to omit from the search
+// SearchHosts find hosts by query containing an IP address, a host name or UUID.
+// Optionally pass a list of IDs to omit from the search
 func (d *Datastore) SearchHosts(query string, omit ...uint) ([]*kolide.Host, error) {
-	hostnameQuery := transformQuery(query)
-	if !queryMinLength(hostnameQuery) {
+	hostQuery := transformQuery(query)
+	if !queryMinLength(hostQuery) {
 		return d.searchHostsDefault(omit...)
 	}
 	if len(omit) > 0 {
@@ -647,7 +647,7 @@ func (d *Datastore) SearchHosts(query string, omit ...uint) ([]*kolide.Host, err
 				SELECT id
 				FROM hosts
 				WHERE
-				MATCH(host_name) AGAINST(? IN BOOLEAN MODE)
+				MATCH(host_name, uuid) AGAINST(? IN BOOLEAN MODE)
 			)
 		OR
 			id IN (
@@ -662,7 +662,7 @@ func (d *Datastore) SearchHosts(query string, omit ...uint) ([]*kolide.Host, err
 	`
 	hosts := []*kolide.Host{}
 
-	if err := d.db.Select(&hosts, sqlStatement, hostnameQuery, ipQuery); err != nil {
+	if err := d.db.Select(&hosts, sqlStatement, hostQuery, ipQuery); err != nil {
 		return nil, errors.Wrap(err, "searching hosts")
 	}
 

--- a/server/datastore/mysql/migrations/tables/20191010155147_UpdateTableHostsSearchIndex.go
+++ b/server/datastore/mysql/migrations/tables/20191010155147_UpdateTableHostsSearchIndex.go
@@ -1,0 +1,41 @@
+package tables
+
+import (
+	"database/sql"
+
+	"github.com/pkg/errors"
+)
+
+func init() {
+	MigrationClient.AddMigration(Up20191010155147, Down20191010155147)
+}
+
+func Up20191010155147(tx *sql.Tx) error {
+	// Update hosts_search fulltext index to allow search by UUID
+	sql := `ALTER TABLE hosts DROP INDEX hosts_search`
+	if _, err := tx.Exec(sql); err != nil {
+		return errors.Wrap(err, "drop old index")
+	}
+
+	sql = `CREATE FULLTEXT INDEX hosts_search ON hosts(host_name, uuid)`
+	if _, err := tx.Exec(sql); err != nil {
+		return errors.Wrap(err, "add updated index")
+	}
+
+	return nil
+}
+
+func Down20191010155147(tx *sql.Tx) error {
+	// Update hosts_search fulltext index to allow search by UUID
+	sql := `ALTER TABLE hosts DROP INDEX hosts_search`
+	if _, err := tx.Exec(sql); err != nil {
+		return errors.Wrap(err, "drop old index")
+	}
+
+	sql = `CREATE FULLTEXT INDEX hosts_search ON hosts(host_name)`
+	if _, err := tx.Exec(sql); err != nil {
+		return errors.Wrap(err, "add updated index")
+	}
+
+	return nil
+}

--- a/server/kolide/hosts.go
+++ b/server/kolide/hosts.go
@@ -80,7 +80,7 @@ type Host struct {
 	SeenTime         time.Time     `json:"seen_time" db:"seen_time"`                  // Time that the host was last "seen"
 	NodeKey          string        `json:"-" db:"node_key"`
 	HostName         string        `json:"hostname" db:"host_name"` // there is a fulltext index on this field
-	UUID             string        `json:"uuid"`
+	UUID             string        `json:"uuid" db:"uuid"`          // there is a fulltext index on this field
 	Platform         string        `json:"platform"`
 	OsqueryVersion   string        `json:"osquery_version" db:"osquery_version"`
 	OSVersion        string        `json:"os_version" db:"os_version"`


### PR DESCRIPTION
When searching hosts, querying the fleet using hostnames and/or IPs may lead to inconsistent results since these can easily vary in time. On the other hand, UUIDs should be a much more "static" way to identify a device.
This change implements search by UUID for the MySQL and in memory datastores.