### PR TITLE
Allow host expiry window to be altered

### DIFF
--- a/server/datastore/mysql/app_configs.go
+++ b/server/datastore/mysql/app_configs.go
@@ -43,12 +43,24 @@ func (d *Datastore) isEventSchedulerEnabled() (bool, error) {
 
 func (d *Datastore) ManageHostExpiryEvent(hostExpiryEnabled bool, hostExpiryWindow int) error {
 	var err error
-
-	if _, err = d.db.Exec("DROP EVENT IF EXISTS host_expiry"); err != nil {
+	hostExpiryConfig := struct {
+		Enabled bool `db:"host_expiry_enabled"`
+		Window  int  `db:"host_expiry_window"`
+	}{}
+	if err = d.db.Get(&hostExpiryConfig, "SELECT host_expiry_enabled,host_expiry_window from app_configs LIMIT 1"); err != nil {
 		return err
 	}
 
-	if hostExpiryEnabled {
+	shouldUpdateWindow := hostExpiryConfig.Window != hostExpiryWindow
+	hostExpiryDisabled := hostExpiryConfig.Enabled && !hostExpiryEnabled
+
+	if hostExpiryDisabled || shouldUpdateWindow {
+		if _, err = d.db.Exec("DROP EVENT IF EXISTS host_expiry"); err != nil {
+			return err
+		}
+	}
+
+	if hostExpiryEnabled || (shouldUpdateWindow && !hostExpiryDisabled) {
 		_, err = d.db.Exec(fmt.Sprintf("CREATE EVENT IF NOT EXISTS host_expiry ON SCHEDULE EVERY 1 HOUR ON COMPLETION PRESERVE DO DELETE FROM hosts WHERE seen_time < DATE_SUB(NOW(), INTERVAL %d DAY)", hostExpiryWindow))
 	}
 	return err

--- a/server/datastore/mysql/app_configs.go
+++ b/server/datastore/mysql/app_configs.go
@@ -42,12 +42,15 @@ func (d *Datastore) isEventSchedulerEnabled() (bool, error) {
 }
 
 func (d *Datastore) ManageHostExpiryEvent(hostExpiryEnabled bool, hostExpiryWindow int) error {
-	if !hostExpiryEnabled {
-		_, err := d.db.Exec("DROP EVENT IF EXISTS host_expiry")
+	var err error
+
+	if _, err = d.db.Exec("DROP EVENT IF EXISTS host_expiry"); err != nil {
 		return err
 	}
 
-	_, err := d.db.Exec(fmt.Sprintf("CREATE EVENT IF NOT EXISTS host_expiry ON SCHEDULE EVERY 1 HOUR ON COMPLETION PRESERVE DO DELETE FROM hosts WHERE seen_time < DATE_SUB(NOW(), INTERVAL %d DAY)", hostExpiryWindow))
+	if hostExpiryEnabled {
+		_, err = d.db.Exec(fmt.Sprintf("CREATE EVENT IF NOT EXISTS host_expiry ON SCHEDULE EVERY 1 HOUR ON COMPLETION PRESERVE DO DELETE FROM hosts WHERE seen_time < DATE_SUB(NOW(), INTERVAL %d DAY)", hostExpiryWindow))
+	}
 	return err
 }
 


### PR DESCRIPTION
Bug on my behalf - if you had left host expiry enabled but changed the window, the event would not be altered to reflect that. Event creation doesn't support upserts unfortunately. SQL is not my forte, so let me know if there's a better way to accomplish this.

Fixes #2122 