### PR TITLE
server/mail: fix dropped error

### DIFF
--- a/server/mail/mail.go
+++ b/server/mail/mail.go
@@ -179,7 +179,12 @@ func (m mailService) sendMail(e kolide.Email, msg []byte) error {
 	if err != nil {
 		return errors.Wrap(err, "getting client data")
 	}
+
 	_, err = writer.Write(msg)
+	if err != nil {
+		return errors.Wrap(err, "failed to write")
+	}
+
 	if err = writer.Close(); err != nil {
 		return errors.Wrap(err, "failed to close writer")
 	}


### PR DESCRIPTION
This PR picks up a dropped error in the `server/mail` package.