### PR TITLE
create a dockerized kolide experience

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
-*
-!build/
+.dockerignore
+Dockerfile*
+docker-compose.yml

--- a/Dockerfile.compose
+++ b/Dockerfile.compose
@@ -1,0 +1,19 @@
+FROM node:10 AS prep
+COPY . /workspace/
+WORKDIR /workspace
+RUN make deps-js
+RUN make generate-js
+
+FROM golang:1 as go
+COPY --from=prep /workspace /workspace
+WORKDIR /workspace
+RUN make deps-go
+RUN make generate-go
+RUN make build
+
+FROM debian:stable-slim
+RUN apt-get update && apt-get install -y ca-certificates
+COPY --from=go /workspace/tools/osquery /workspace/tools/osquery
+COPY --from=go /workspace/build/fleet /workspace/build/fleetctl /usr/bin/
+WORKDIR /workspace
+CMD ["fleet", "serve"]

--- a/Dockerfile.osquery
+++ b/Dockerfile.osquery
@@ -1,0 +1,4 @@
+FROM debian:stable-slim
+RUN apt-get update && apt-get install -y wget
+RUN wget https://pkg.osquery.io/deb/osquery_4.0.2_1.linux.amd64.deb
+RUN dpkg -i osquery_4.0.2_1.linux.amd64.deb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       KOLIDE_MYSQL_ADDRESS: mysql:3306
       KOLIDE_MYSQL_PASSWORD: kolide
       KOLIDE_REDIS_ADDRESS: redis:6379
-      KOLIDE_AUTH_JWT_KEY: E6VMWGBgZkKzfY/dw3zsZMd9foPsUrmL
+      KOLIDE_AUTH_JWT_KEY: FAKESECRETFake/thisisjustfakekey
     ports:
       - "443:443"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "(
           while ! grep -q 00:01BB /proc/net/tcp6;do echo wait;sleep 1;done; \
           fleetctl config set --address https://localhost:443 --tls-skip-verify; \
-          fleetctl setup --email kolide@kolide.com --password kolide; \
+          fleetctl setup --email kolide@example.com --password kolide; \
           fleetctl get enroll-secret > /data/enroll-secret;cp ./tools/osquery/kolide.crt /data/ \
         ) & \
         fleet prepare db && fleet serve"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,36 @@
 version: '2'
 services:
+  fleet:
+    build:
+      context: .
+      dockerfile: Dockerfile.compose
+    image: kolide-local
+    command:
+      - /bin/bash
+      - "-c"
+      - "(
+          while ! grep -q 00:01BB /proc/net/tcp6;do echo wait;sleep 1;done; \
+          fleetctl config set --address https://localhost:443 --tls-skip-verify; \
+          fleetctl setup --email kolide@kolide.com --password kolide; \
+          fleetctl get enroll-secret > /data/enroll-secret;cp ./tools/osquery/kolide.crt /data/ \
+        ) & \
+        fleet prepare db && fleet serve"
+    environment:
+      KOLIDE_SERVER_ADDRESS: 0.0.0.0:443
+      KOLIDE_MYSQL_ADDRESS: mysql:3306
+      KOLIDE_MYSQL_PASSWORD: kolide
+      KOLIDE_REDIS_ADDRESS: redis:6379
+      KOLIDE_AUTH_JWT_KEY: E6VMWGBgZkKzfY/dw3zsZMd9foPsUrmL
+    ports:
+      - "443:443"
+    volumes:
+      - app-volume:/data
+    restart: on-failure
+    depends_on:
+      - mysql
+
   mysql:
     image: mysql:5.7
-    volumes:
-      - .:/tmp
     command: mysqld --datadir=/tmp/mysqldata --slow_query_log=1 --log_output=TABLE --log-queries-not-using-indexes --event-scheduler=ON
     environment:
       MYSQL_ROOT_PASSWORD: toor
@@ -35,3 +62,37 @@ services:
     image: redis:3.2.4
     ports:
       - "6379:6379"
+
+
+  linux:
+    build:
+      context: .
+      dockerfile: Dockerfile.osquery
+    image: linux-local
+    command:
+      - /bin/bash
+      - "-c"
+      - "osqueryd \
+        --enroll_secret_path /data/enroll-secret \
+        --tls_server_certs=/data/kolide.crt \
+        --tls_hostname=fleet \
+        --host_identifier=uuid \
+        --enroll_tls_endpoint=/api/v1/osquery/enroll \
+        --config_plugin=tls \
+        --config_tls_endpoint=/api/v1/osquery/config \
+        --config_refresh=10 \
+        --disable_distributed=false \
+        --distributed_plugin=tls \
+        --distributed_interval=10 \
+        --distributed_tls_max_attempts=3 \
+        --distributed_tls_read_endpoint=/api/v1/osquery/distributed/read \
+        --distributed_tls_write_endpoint=/api/v1/osquery/distributed/write \
+        --logger_plugin=tls \
+        --logger_tls_endpoint=/api/v1/osquery/log \
+        --logger_tls_period=10"
+    volumes:
+      - app-volume:/data
+    restart: on-failure
+
+volumes:
+    app-volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       KOLIDE_MYSQL_ADDRESS: mysql:3306
       KOLIDE_MYSQL_PASSWORD: kolide
       KOLIDE_REDIS_ADDRESS: redis:6379
-      KOLIDE_AUTH_JWT_KEY: FAKESECRETFake/thisisjustfakekey
+      KOLIDE_AUTH_JWT_KEY: insecure
     ports:
       - "443:443"
     volumes:


### PR DESCRIPTION
This change convert the docker-compose so we can test it only with docker as dependency.
no need to have node/go other other tools locally.

```bash
docker-compose up
```
When all containers start eventually (they can fail and restart) we can open https://localhost and login with:
`username: kolide@kolide.com`
`password: kolide`

There will be already one node registered there.



