### PR TITLE
Fix SSO Dropped Test Errors

### DIFF
--- a/server/sso/validate_test.go
+++ b/server/sso/validate_test.go
@@ -97,7 +97,10 @@ func TestVerfiyStaleMessageFails(t *testing.T) {
 	validator, err := NewValidator(testMetadata, Clock(clock))
 	require.Nil(t, err)
 	require.NotNil(t, validator)
+
 	auth, err := DecodeAuthResponse(testResponse)
+	require.Nil(t, err)
+
 	signed, err := validator.ValidateSignature(auth)
 	require.Nil(t, err)
 	require.NotNil(t, signed)

--- a/server/sso/validate_test.go
+++ b/server/sso/validate_test.go
@@ -41,11 +41,15 @@ var testResponse = `PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c2FtbHA6
 func TestValidate(t *testing.T) {
 	tm, err := time.Parse(time.UnixDate, "Sun Apr 30 22:10:00 UTC 2017")
 	require.Nil(t, err)
+
 	clock := dsig.NewFakeClockAt(tm)
 	validator, err := NewValidator(testMetadata, Clock(clock))
 	require.Nil(t, err)
 	require.NotNil(t, validator)
+
 	auth, err := DecodeAuthResponse(testResponse)
+	require.Nil(t, err)
+
 	signed, err := validator.ValidateSignature(auth)
 	require.Nil(t, err)
 	require.NotNil(t, signed)

--- a/server/sso/validate_test.go
+++ b/server/sso/validate_test.go
@@ -78,13 +78,18 @@ func tamperedResponse(original string) (string, error) {
 func TestVerfiyValidTamperedWithDocFails(t *testing.T) {
 	tampered, err := tamperedResponse(testResponse)
 	require.Nil(t, err)
+
 	tm, err := time.Parse(time.UnixDate, "Sun Apr 30 22:10:00 UTC 2017")
 	require.Nil(t, err)
+
 	clock := dsig.NewFakeClockAt(tm)
 	validator, err := NewValidator(testMetadata, Clock(clock))
 	require.Nil(t, err)
 	require.NotNil(t, validator)
+
 	auth, err := DecodeAuthResponse(tampered)
+	require.Nil(t, err)
+
 	_, err = validator.ValidateSignature(auth)
 	require.NotNil(t, err)
 }


### PR DESCRIPTION
This PR fixes three dropped errors in the `server/sso` tests.