### PR TITLE
Remove Support for Deprecated TLSProfileOld

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -393,30 +393,6 @@ func getTLSConfig(profile string) *tls.Config {
 			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
 			tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
 		)
-	case config.TLSProfileOld:
-		cfg.MinVersion = tls.VersionSSL30
-		cfg.CurvePreferences = append(cfg.CurvePreferences,
-			tls.CurveP256,
-			tls.CurveP384,
-			tls.CurveP521,
-			tls.X25519,
-		)
-		cfg.CipherSuites = append(cfg.CipherSuites,
-			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
-			tls.TLS_RSA_WITH_RC4_128_SHA,
-			tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
-		)
 	default:
 		panic("invalid tls profile " + profile)
 	}

--- a/docs/infrastructure/configuring-the-fleet-binary.md
+++ b/docs/infrastructure/configuring-the-fleet-binary.md
@@ -365,7 +365,7 @@ Whether or not the server should be served over TLS.
 
 ##### `server_tls_compatibility`
 
-Configures the TLS settings for compatibility with various user agents. Options are `modern`, `intermediate`, and `old` (deprecated). These correspond to the compatibility levels [defined by the Mozilla OpSec team](https://wiki.mozilla.org/Security/Server_Side_TLS)
+Configures the TLS settings for compatibility with various user agents. Options are `modern` and `intermediate`. These correspond to the compatibility levels [defined by the Mozilla OpSec team](https://wiki.mozilla.org/Security/Server_Side_TLS)
 
 - Default value: `modern`
 - Environment variable: `KOLIDE_SERVER_TLS_COMPATIBILITY`

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -43,7 +43,6 @@ const (
 	TLSProfileKey          = "server.tls_compatibility"
 	TLSProfileModern       = "modern"
 	TLSProfileIntermediate = "intermediate"
-	TLSProfileOld          = "old"
 )
 
 // ServerConfig defines configs related to the Fleet server
@@ -193,8 +192,8 @@ func (man Manager) addConfigs() {
 	man.addConfigBool("server.tls", true,
 		"Enable TLS (required for osqueryd communication)")
 	man.addConfigString(TLSProfileKey, TLSProfileModern,
-		fmt.Sprintf("TLS security profile choose one of %s, %s or %s",
-			TLSProfileModern, TLSProfileIntermediate, TLSProfileOld))
+		fmt.Sprintf("TLS security profile choose one of %s or %s",
+			TLSProfileModern, TLSProfileIntermediate))
 	man.addConfigString("server.url_prefix", "",
 		"URL prefix used on server and frontend endpoints")
 
@@ -473,12 +472,9 @@ func (man Manager) getConfigTLSProfile() string {
 	}
 	switch sval {
 	case TLSProfileModern, TLSProfileIntermediate:
-		// no error
-	case TLSProfileOld:
-		fmt.Println(`WARNING: TLS profile "old" has been deprecated and will soon be removed. If you rely on this feature, please open an issue on GitHub.`)
 	default:
-		panic(fmt.Sprintf("%s must be one of %s, %s or %s", TLSProfileKey,
-			TLSProfileModern, TLSProfileIntermediate, TLSProfileOld))
+		panic(fmt.Sprintf("%s must be one of %s or %s", TLSProfileKey,
+			TLSProfileModern, TLSProfileIntermediate))
 	}
 	return sval
 }


### PR DESCRIPTION
The Go authors deprecated support for SSLv3 in go 1.13. They've decided to remove it in go 1.14, and have already merged the commit. 

See: https://golang.org/issue/32716

This PR, or something like it, should probably land before February 2020.