### PR TITLE
Upgrade lodash to 4.17.15 for security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "isomorphic-fetch": "2.2.1",
     "js-md5": "0.7.3",
     "jsdom": "9.12.0",
-    "lodash": "4.17.11",
+    "lodash": "^4.17.15",
     "memoize-one": "^5",
     "moment": "2.22.2",
     "nock": "8.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5035,11 +5035,6 @@ lodash@4.16.4:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.4.tgz#01ce306b9bad1319f2a5528674f88297aeb70127"
   integrity sha1-Ac4wa5utExnypVKGdPiCl663ASc=
 
-lodash@4.17.11:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
-
 lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@~4.17.10:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"


### PR DESCRIPTION
There was a prototype pollution vulnerability in 4.17.11 that is
unlikely to have high impact on Fleet due to all JS executing on the
client side. Upgrading lodash to satisfy security warnings from
Github.