### PR TITLE
Update Makefile to tag and push version to Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,10 +188,12 @@ endif
 
 docker-build-release: xp-fleet xp-fleetctl
 	docker build -t "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" .
+	docker tag "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" kolide/fleet:${VERSION}
 	docker tag "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" kolide/fleet:latest
 
 docker-push-release: docker-build-release
 	docker push "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
+	docker push kolide/fleet:${VERSION}
 	docker push kolide/fleet:latest
 
 docker-build-circle:


### PR DESCRIPTION
Previously only the Git SHA and `latest` were pushed by default and
the version had to be tagged and pushed manually. This further
automates the release process.