### PR TITLE
check if status is not nil before deciding that all hosts have responded

### DIFF
--- a/cmd/fleetctl/query.go
+++ b/cmd/fleetctl/query.go
@@ -160,7 +160,7 @@ func queryCommand() cli.Command {
 					if !flQuiet {
 						s.Suffix = msg
 					}
-					if total == responded {
+					if status != nil && total == responded {
 						s.Stop()
 						if !flQuiet {
 							fmt.Fprintln(os.Stderr, msg)


### PR DESCRIPTION
Currently, the `total == responded` line in `query.go` will resolve to true if the Fleet server has not returned any data, as 0/0 hosts are returning any information. However, this may not necessarily mean that Fleet should exit, as the values also resolve to zero if the websocket responses have not been return yet. Forcing status to also be not nil allows us to keep the connection ongoing until responses are returned.
This contribution was co-researched with @4ndygu 