### PR TITLE
Add MysqlConfig Protocol which enables Unix Domain Sockets to work

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -17,6 +17,7 @@ const (
 
 // MysqlConfig defines configs related to MySQL
 type MysqlConfig struct {
+	Protocol      string
 	Address       string
 	Username      string
 	Password      string
@@ -135,6 +136,8 @@ type KolideConfig struct {
 // filled into the KolideConfig struct
 func (man Manager) addConfigs() {
 	// MySQL
+	man.addConfigString("mysql.protocol", "tcp",
+		"MySQL server communication protocol (tcp,unix,...)")
 	man.addConfigString("mysql.address", "localhost:3306",
 		"MySQL server address (host:port)")
 	man.addConfigString("mysql.username", "kolide",
@@ -253,6 +256,7 @@ func (man Manager) LoadConfig() KolideConfig {
 
 	return KolideConfig{
 		Mysql: MysqlConfig{
+			Protocol:      man.getConfigString("mysql.protocol"),
 			Address:       man.getConfigString("mysql.address"),
 			Username:      man.getConfigString("mysql.username"),
 			Password:      man.getConfigString("mysql.password"),

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -274,9 +274,10 @@ func registerTLS(config config.MysqlConfig) error {
 func generateMysqlConnectionString(conf config.MysqlConfig) string {
 	tz := url.QueryEscape("'-00:00'")
 	dsn := fmt.Sprintf(
-		"%s:%s@(%s)/%s?charset=utf8mb4&parseTime=true&loc=UTC&time_zone=%s&clientFoundRows=true&allowNativePasswords=true",
+		"%s:%s@%s(%s)/%s?charset=utf8mb4&parseTime=true&loc=UTC&time_zone=%s&clientFoundRows=true&allowNativePasswords=true",
 		conf.Username,
 		conf.Password,
+		conf.Protocol,
 		conf.Address,
 		conf.Database,
 		tz,


### PR DESCRIPTION
I added a MysqlConfig Protocol option (default: "tcp") which can be used to configure Fleet to connect to mysql using a unix domain socket. This is useful when deploying Fleet on Google Cloud Run and connecting to a Cloud SQL database.

This is an example using Cloud Run with the new `KOLIDE_MYSQL_PROTOCOL` environment variable:

```
gcloud beta run \
deploy \
fleet \
--platform=managed \
--region=us-central1 \
--image=gcr.io/$PROJECT/fleet:2.4.1 \
--add-cloudsql-instances \
$PROJECT:us-west2:$MYSQL_INSTANCE \
--set-env-vars=INSTANCE-CONNECTION-NAME=$PROJECT:us-west2:$MYSQL_INSTANCE,KOLIDE_MYSQL_PROTOCOL=unix,KOLIDE_MYSQL_ADDRESS=/cloudsql/$PROJECT:us-west2:$MYSQL_INSTANCE,KOLIDE_MYSQL_DATABASE=kolide,KOLIDE_MYSQL_USERNAME=kolide,KOLIDE_MYSQL_PASSWORD=kolide,KOLIDE_REDIS_ADDRESS=127.0.0.1:6379,KOLIDE_SERVER_TLS=false,KOLIDE_LOGGING_JSON=true,KOLIDE_AUTH_JWT_KEY=changeme
```

The command is messy because the environment variables are all stuck together, but the important configuration variables are:

```
KOLIDE_MYSQL_PROTOCOL=unix
KOLIDE_MYSQL_ADDRESS=/cloudsql/$PROJECT:us-west2:$MYSQL_INSTANCE
```

The problem is the `generateMysqlConnectionString` function declares the data source name without space for the "unix" protocol to land. There an example data source name at:

https://pear.php.net/manual/en/package.database.db.intro-dsn.php

```
Connect to database through a socket

mysql://user@unix(/path/to/socket)/pear
```

See the unix outside the parenthesis?

I've verified the tests still pass with `make test-go` (but haven't added new tests) and have deploying the linux binary that came out of `make xp-fleet` to Cloud Run and it worked!

Closes #2160