### PR TITLE
Update goxmldsig dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/VividCortex/mysqlerr v0.0.0-20170204212430-6c6b55f8796f
 	github.com/WatchBeam/clock v0.0.0-20170901150240-b08e6b4da7ea
 	github.com/aws/aws-sdk-go v1.19.8
-	github.com/beevik/etree v1.0.0
+	github.com/beevik/etree v1.1.0
 	github.com/briandowns/spinner v0.0.0-20170614154858-48dbb65d7bd5
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/e-dard/netbug v0.0.0-20151029172837-e64d308a0b20
@@ -46,7 +46,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/russellhaering/gosaml2 v0.3.1
-	github.com/russellhaering/goxmldsig v0.0.0-20170911191014-b7efc6231e45
+	github.com/russellhaering/goxmldsig v0.0.0-20180430223755-7acd5e4a6ef7
 	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/spf13/afero v1.1.0 // indirect
 	github.com/spf13/cast v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/aws/aws-sdk-go v1.19.8 h1:hTQRVRsg4Fwvm8SODN5ufmlqRUqFCLl/xG+BXabqVXw
 github.com/aws/aws-sdk-go v1.19.8/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beevik/etree v1.0.0 h1:gQ0/0GdWwIZONSQVL/btX2rZ/OwMSV7twGyq42D+KUg=
 github.com/beevik/etree v1.0.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
+github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
+github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/briandowns/spinner v0.0.0-20170614154858-48dbb65d7bd5 h1:osZyZB7J4kE1tKLeaUjV6+uZVBfS835T0I/RxmwWw1w=
@@ -165,6 +167,8 @@ github.com/russellhaering/gosaml2 v0.3.1 h1:s+Oz2RRS83uqocWhWdR8Gbtze4g84cWQqNUm
 github.com/russellhaering/gosaml2 v0.3.1/go.mod h1:niieRtQaw+opTVp9jzZo1nAAoksI2eNpd+weDcjZ+Mk=
 github.com/russellhaering/goxmldsig v0.0.0-20170911191014-b7efc6231e45 h1:whMeRuFKfeiOC2mBJo5uEeASLjzkynDQAhdbwzCjcX4=
 github.com/russellhaering/goxmldsig v0.0.0-20170911191014-b7efc6231e45/go.mod h1:Oz4y6ImuOQZxynhbSXk7btjEfNBtGlj2dcaOvXl2FSM=
+github.com/russellhaering/goxmldsig v0.0.0-20180430223755-7acd5e4a6ef7 h1:J4AOUcOh/t1XbQcJfkEqhzgvMJ2tDxdCVvmHxW5QXao=
+github.com/russellhaering/goxmldsig v0.0.0-20180430223755-7acd5e4a6ef7/go.mod h1:Oz4y6ImuOQZxynhbSXk7btjEfNBtGlj2dcaOvXl2FSM=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/server/sso/settings_test.go
+++ b/server/sso/settings_test.go
@@ -51,7 +51,7 @@ func TestParseMetadata(t *testing.T) {
 	assert.Equal(t, "http://www.okta.com/exka4zkf6dxm8pF220h7", settings.EntityID)
 	assert.Len(t, settings.IDPSSODescriptor.NameIDFormats, 2)
 	require.Len(t, settings.IDPSSODescriptor.KeyDescriptors, 1)
-	assert.True(t, settings.IDPSSODescriptor.KeyDescriptors[0].KeyInfo.X509Data.X509Certificate.Data != "")
+	assert.True(t, settings.IDPSSODescriptor.KeyDescriptors[0].KeyInfo.X509Data.X509Certificates[0].Data != "")
 	require.Len(t, settings.IDPSSODescriptor.SingleSignOnService, 2)
 	assert.Equal(t, "https://dev-132038.oktapreview.com/app/kolidedev132038_kolide_1/exka4zkf6dxm8pF220h7/sso/saml",
 		settings.IDPSSODescriptor.SingleSignOnService[0].Location)
@@ -70,7 +70,7 @@ func TestGetMetadata(t *testing.T) {
 	assert.Equal(t, "http://www.okta.com/exka4zkf6dxm8pF220h7", settings.EntityID)
 	assert.Len(t, settings.IDPSSODescriptor.NameIDFormats, 2)
 	require.Len(t, settings.IDPSSODescriptor.KeyDescriptors, 1)
-	assert.True(t, settings.IDPSSODescriptor.KeyDescriptors[0].KeyInfo.X509Data.X509Certificate.Data != "")
+	assert.True(t, settings.IDPSSODescriptor.KeyDescriptors[0].KeyInfo.X509Data.X509Certificates[0].Data != "")
 	require.Len(t, settings.IDPSSODescriptor.SingleSignOnService, 2)
 	assert.Equal(t, "https://dev-132038.oktapreview.com/app/kolidedev132038_kolide_1/exka4zkf6dxm8pF220h7/sso/saml",
 		settings.IDPSSODescriptor.SingleSignOnService[0].Location)

--- a/server/sso/validate.go
+++ b/server/sso/validate.go
@@ -44,7 +44,10 @@ func NewValidator(metadata string, opts ...func(v *validator)) (Validator, error
 	}
 	var idpCertStore dsig.MemoryX509CertificateStore
 	for _, key := range v.metadata.IDPSSODescriptor.KeyDescriptors {
-		certData, err := base64.StdEncoding.DecodeString(strings.TrimSpace(key.KeyInfo.X509Data.X509Certificate.Data))
+		if len(key.KeyInfo.X509Data.X509Certificates) == 0 {
+			return nil, errors.New("missing x509 cert")
+		}
+		certData, err := base64.StdEncoding.DecodeString(strings.TrimSpace(key.KeyInfo.X509Data.X509Certificates[0].Data))
 		if err != nil {
 			return nil, errors.Wrap(err, "decoding idp x509 cert")
 		}


### PR DESCRIPTION
Update the github.com/russellhaering/goxmldsig dependency and apply
the appropriate fixes for the API changes.

This is a preparation for integration with
github.com/AbGuthrie/goquery, which uses a newer version of the
dependency.