### PR TITLE
Add deprecation warning for "old" TLS compatibility

### DIFF
--- a/docs/infrastructure/configuring-the-fleet-binary.md
+++ b/docs/infrastructure/configuring-the-fleet-binary.md
@@ -340,7 +340,7 @@ Whether or not the server should be served over TLS.
 
 ##### `server_tls_compatibility`
 
-Configures the TLS settings for compatibility with various user agents. Options are `modern`, `intermediate`, and `old`. These correspond to the compatibility levels [defined by the Mozilla OpSec team](https://wiki.mozilla.org/Security/Server_Side_TLS)
+Configures the TLS settings for compatibility with various user agents. Options are `modern`, `intermediate`, and `old` (deprecated). These correspond to the compatibility levels [defined by the Mozilla OpSec team](https://wiki.mozilla.org/Security/Server_Side_TLS)
 
 - Default value: `modern`
 - Environment variable: `KOLIDE_SERVER_TLS_COMPATIBILITY`

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -427,7 +427,10 @@ func (man Manager) getConfigTLSProfile() string {
 		panic(fmt.Sprintf("%s requires a string value: %s", TLSProfileKey, err.Error()))
 	}
 	switch sval {
-	case TLSProfileModern, TLSProfileIntermediate, TLSProfileOld:
+	case TLSProfileModern, TLSProfileIntermediate:
+		// no error
+	case TLSProfileOld:
+		fmt.Println(`WARNING: TLS profile "old" has been deprecated and will soon be removed. If you rely on this feature, please open an issue on GitHub.`)
 	default:
 		panic(fmt.Sprintf("%s must be one of %s, %s or %s", TLSProfileKey,
 			TLSProfileModern, TLSProfileIntermediate, TLSProfileOld))


### PR DESCRIPTION
Warn users in advance of removing this in #2142.