### PR TITLE
Require non-nil status for exit of fleetctl query

### DIFF
--- a/cmd/fleetctl/query.go
+++ b/cmd/fleetctl/query.go
@@ -160,7 +160,7 @@ func queryCommand() cli.Command {
 					if !flQuiet {
 						s.Suffix = msg
 					}
-					if total == responded {
+					if total == responded && status != nil {
 						s.Stop()
 						if !flQuiet {
 							fmt.Fprintln(os.Stderr, msg)


### PR DESCRIPTION
Fixes an issue some users encountered in which the query would exit
before any results were returned (when latency to the Fleet server was
high).