### PR TITLE
Adding queryName flag to fleetctl

### DIFF
--- a/cmd/fleetctl/query.go
+++ b/cmd/fleetctl/query.go
@@ -105,8 +105,6 @@ func queryCommand() cli.Command {
 				}
 			}
 
-			//fmt.Printf("%+v", flQuery)
-
 			hosts := strings.Split(flHosts, ",")
 			labels := strings.Split(flLabels, ",")
 

--- a/cmd/fleetctl/query.go
+++ b/cmd/fleetctl/query.go
@@ -64,11 +64,11 @@ func queryCommand() cli.Command {
 				Usage:       "Query to run",
 			},
 			cli.StringFlag{
-				Name:        "queryName",
+				Name:        "query-name",
 				EnvVar:      "QUERYNAME",
 				Value:       "",
 				Destination: &flQueryName,
-				Usage:       "Query name to run - overlaps query var",
+				Usage:       "Name of saved query to run",
 			},
 			cli.BoolFlag{
 				Name:        "debug",
@@ -93,16 +93,16 @@ func queryCommand() cli.Command {
 				return errors.New("No hosts or labels targeted")
 			}
 
+			if flQuery != "" && flQueryName != "" {
+				return errors.New("Don't specify query and query name at the same time")
+			}
+
 			if flQueryName != "" {
 				q, err := fleet.GetQuery(flQueryName)
 				if err != nil {
-					return err
+					return errors.New("No query found")
 				}
 				flQuery = q.Query
-			} else {
-				if flQuery == "" {
-					return errors.New("No query specified")
-				}
 			}
 
 			hosts := strings.Split(flHosts, ",")

--- a/cmd/fleetctl/query.go
+++ b/cmd/fleetctl/query.go
@@ -94,15 +94,19 @@ func queryCommand() cli.Command {
 			}
 
 			if flQuery != "" && flQueryName != "" {
-				return errors.New("Don't specify query and query name at the same time")
+				return fmt.Errorf("--query and --query-name must not be provided together")
 			}
 
 			if flQueryName != "" {
 				q, err := fleet.GetQuery(flQueryName)
 				if err != nil {
-					return errors.New("No query found")
+					return fmt.Errorf("Query '%s' not found", flQueryName)
 				}
 				flQuery = q.Query
+			}
+
+			if flQuery == "" {
+				return fmt.Errorf("Query must be specified with --query or --query-name")
 			}
 
 			hosts := strings.Split(flHosts, ",")
@@ -183,7 +187,7 @@ func queryCommand() cli.Command {
 						return nil
 					}
 
-				// Check for timeout expiringpo
+				// Check for timeout expiring
 				case <-timeoutChan:
 					s.Stop()
 					if !flQuiet {


### PR DESCRIPTION
Added a feature to select queries by name. If --queryName flag it's defined, fleetctl makes a call to get the query already saved in fleet, and then, if it exists, fill flquery variable with the selected query statement.

Closes #2175