### PR TITLE
Fix description for "Fleet App URL" config option

### DIFF
--- a/frontend/components/forms/RegistrationForm/RegistrationForm.jsx
+++ b/frontend/components/forms/RegistrationForm/RegistrationForm.jsx
@@ -103,10 +103,7 @@ class RegistrationForm extends Component {
     if (page === 3) {
       return (
         <div className={`${baseClass}__description`}>
-          <p>Define the base URL that clients will use to connect to Fleet.</p>
-          <p>
-            <small>Note: Please ensure the URL is accessible to all endpoints that will be managed by Fleet. The hostname must match the name on your TLS certificate.</small>
-          </p>
+          <p>Define the base URL of this Fleet instance.</p>
         </div>
       );
     }

--- a/frontend/components/forms/admin/AppConfigForm/AppConfigForm.jsx
+++ b/frontend/components/forms/admin/AppConfigForm/AppConfigForm.jsx
@@ -191,8 +191,7 @@ class AppConfigForm extends Component {
             />
           </div>
           <div className={`${baseClass}__details`}>
-            <p>What base URL should <strong>osqueryd</strong> clients use to connect and register with <strong>Fleet</strong>?</p>
-            <p className={`${baseClass}__note`}><strong>Note:</strong> Please ensure the URL you choose is accessible to all endpoints that need to communicate with Fleet, otherwise they will not be able to correctly register.</p>
+            <p>The base URL of this instance for use in <strong>Fleet</strong> links.</p>
           </div>
         </div>
 

--- a/frontend/components/forms/admin/AppConfigForm/_styles.scss
+++ b/frontend/components/forms/admin/AppConfigForm/_styles.scss
@@ -88,11 +88,6 @@
       line-height: 1.6;
       letter-spacing: 0.5px;
       color: $text-dark;
-
-      &.app-config-form__note {
-        font-size: 13px;
-        color: $text-medium;
-      }
     }
 
     .hint {


### PR DESCRIPTION
Remove a misleading warning: the "Fleet App URL" configuration parameter is only used by Fleet-internal (i.e. non-`osqueryd`) endpoints.