### PR TITLE
server/datastore: fix dropped test errors

### DIFF
--- a/server/datastore/datastore_hosts_test.go
+++ b/server/datastore/datastore_hosts_test.go
@@ -149,6 +149,7 @@ func testIdempotentDeleteHost(t *testing.T, ds kolide.Datastore) {
 	require.NotNil(t, host)
 	id := host.ID
 	err = ds.DeleteHost(host.ID)
+	assert.Nil(t, err)
 
 	host, err = ds.Host(host.ID)
 	assert.NotNil(t, err)

--- a/server/datastore/datastore_unicode_test.go
+++ b/server/datastore/datastore_unicode_test.go
@@ -35,6 +35,7 @@ func testUnicode(t *testing.T, ds kolide.Datastore) {
 	require.Nil(t, err)
 
 	host, err = ds.Host(host.ID)
+	require.Nil(t, err)
 	assert.Equal(t, "🍌", host.HostName)
 
 	user, err := ds.NewUser(&kolide.User{Username: "🍱", Password: []byte{}})
@@ -47,5 +48,6 @@ func testUnicode(t *testing.T, ds kolide.Datastore) {
 	pack := test.NewPack(t, ds, "👨🏾‍🚒")
 
 	pack, err = ds.Pack(pack.ID)
+	require.Nil(t, err)
 	assert.Equal(t, "👨🏾‍🚒", pack.Name)
 }


### PR DESCRIPTION
This fixes three dropped test errors in `server/datastore`.