### PR TITLE
server/service: Fix Dropped Test Errors

### DIFF
--- a/server/service/http_auth_test.go
+++ b/server/service/http_auth_test.go
@@ -132,6 +132,7 @@ func TestLogin(t *testing.T) {
 
 		// ensure that our user's session was deleted from the store
 		sessions, err = ds.ListSessionsForUser(testUser.ID)
+		assert.Nil(t, err)
 		assert.Len(t, sessions, 0)
 	}
 }

--- a/server/service/service_targets_test.go
+++ b/server/service/service_targets_test.go
@@ -70,6 +70,7 @@ func TestSearchWithOmit(t *testing.T) {
 		Name:  "label foo",
 		Query: "query foo",
 	})
+	require.Nil(t, err)
 
 	{
 		results, err := svc.SearchTargets(ctx, "foo", nil, nil)

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -25,6 +25,7 @@ func TestRotateLoggerSIGHUP(t *testing.T) {
 	defer os.Remove(f.Name())
 
 	logFile, err := logging.NewFilesystemLogWriter(f.Name(), log.NewNopLogger(), true)
+	require.Nil(t, err)
 
 	// write a log line
 	logFile.Write(ctx, []json.RawMessage{json.RawMessage("msg1")})

--- a/server/service/service_users_test.go
+++ b/server/service/service_users_test.go
@@ -72,6 +72,7 @@ func TestModifyUserEmail(t *testing.T) {
 		return nil
 	}
 	svc, err := newTestService(ms, nil)
+	require.Nil(t, err)
 	ctx := context.Background()
 	ctx = viewer.NewContext(ctx, viewer.Viewer{User: user})
 	payload := kolide.UserPayload{

--- a/server/service/service_users_test.go
+++ b/server/service/service_users_test.go
@@ -195,6 +195,7 @@ func TestModifyAdminUserEmailNoPassword(t *testing.T) {
 		return nil
 	}
 	svc, err := newTestService(ms, nil)
+	require.Nil(t, err)
 	ctx := context.Background()
 	ctx = viewer.NewContext(ctx, viewer.Viewer{User: user})
 	payload := kolide.UserPayload{

--- a/server/service/service_users_test.go
+++ b/server/service/service_users_test.go
@@ -107,6 +107,7 @@ func TestModifyUserCannotUpdateAdminEnabled(t *testing.T) {
 		return nil
 	}
 	svc, err := newTestService(ms, nil)
+	require.Nil(t, err)
 	ctx := context.Background()
 	ctx = viewer.NewContext(ctx, viewer.Viewer{User: user})
 	payload := kolide.UserPayload{

--- a/server/service/service_users_test.go
+++ b/server/service/service_users_test.go
@@ -242,6 +242,7 @@ func TestModifyAdminUserEmailPassword(t *testing.T) {
 		return nil
 	}
 	svc, err := newTestService(ms, nil)
+	require.Nil(t, err)
 	ctx := context.Background()
 	ctx = viewer.NewContext(ctx, viewer.Viewer{User: user})
 	payload := kolide.UserPayload{

--- a/server/service/service_users_test.go
+++ b/server/service/service_users_test.go
@@ -674,6 +674,7 @@ func TestPerformRequiredPasswordReset(t *testing.T) {
 			session, err := ds.NewSession(&kolide.Session{
 				UserID: user.ID,
 			})
+			require.Nil(t, err)
 			ctx = viewer.NewContext(ctx, viewer.Viewer{User: user, Session: session})
 
 			// should error when reset not required

--- a/server/service/service_users_test.go
+++ b/server/service/service_users_test.go
@@ -148,6 +148,7 @@ func TestModifyUserEmailNoPassword(t *testing.T) {
 		return nil
 	}
 	svc, err := newTestService(ms, nil)
+	require.Nil(t, err)
 	ctx := context.Background()
 	ctx = viewer.NewContext(ctx, viewer.Viewer{User: user})
 	payload := kolide.UserPayload{


### PR DESCRIPTION
This fixes 9 places in the `server/service` tests where err variables were being dropped.