### PR TITLE
Make HostResponse an exported type

### DIFF
--- a/server/service/client_hosts.go
+++ b/server/service/client_hosts.go
@@ -8,7 +8,7 @@ import (
 )
 
 // GetHosts retrieves the list of all Hosts
-func (c *Client) GetHosts() ([]hostResponse, error) {
+func (c *Client) GetHosts() ([]HostResponse, error) {
 	response, err := c.AuthenticatedDo("GET", "/api/v1/kolide/hosts", nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "GET /api/v1/kolide/hosts")

--- a/server/service/client_targets.go
+++ b/server/service/client_targets.go
@@ -47,7 +47,7 @@ func (c *Client) SearchTargets(query string, selectedHostIDs, selectedLabelIDs [
 
 	hosts := make([]kolide.Host, len(responseBody.Targets.Hosts))
 	for i, h := range responseBody.Targets.Hosts {
-		hosts[i] = h.hostResponse.Host
+		hosts[i] = h.HostResponse.Host
 	}
 
 	labels := make([]kolide.Label, len(responseBody.Targets.Labels))

--- a/server/service/endpoint_hosts.go
+++ b/server/service/endpoint_hosts.go
@@ -8,14 +8,17 @@ import (
 	"github.com/kolide/fleet/server/kolide"
 )
 
-type hostResponse struct {
+// HostResponse is the response struct that contains the full host information
+// along with the host online status and the "display text" to be used when
+// rendering in the UI.
+type HostResponse struct {
 	kolide.Host
 	Status      string `json:"status"`
 	DisplayText string `json:"display_text"`
 }
 
-func hostResponseForHost(ctx context.Context, svc kolide.Service, host *kolide.Host) (*hostResponse, error) {
-	return &hostResponse{
+func hostResponseForHost(ctx context.Context, svc kolide.Service, host *kolide.Host) (*HostResponse, error) {
+	return &HostResponse{
 		Host:        *host,
 		Status:      host.Status(time.Now()),
 		DisplayText: host.HostName,
@@ -31,7 +34,7 @@ type getHostRequest struct {
 }
 
 type getHostResponse struct {
-	Host *hostResponse `json:"host"`
+	Host *HostResponse `json:"host"`
 	Err  error         `json:"error,omitempty"`
 }
 
@@ -65,7 +68,7 @@ type listHostsRequest struct {
 }
 
 type listHostsResponse struct {
-	Hosts []hostResponse `json:"hosts"`
+	Hosts []HostResponse `json:"hosts"`
 	Err   error          `json:"error,omitempty"`
 }
 
@@ -79,7 +82,7 @@ func makeListHostsEndpoint(svc kolide.Service) endpoint.Endpoint {
 			return listHostsResponse{Err: err}, nil
 		}
 
-		hostResponses := make([]hostResponse, len(hosts))
+		hostResponses := make([]HostResponse, len(hosts))
 		for i, host := range hosts {
 			h, err := hostResponseForHost(ctx, svc, host)
 			if err != nil {

--- a/server/service/endpoint_targets.go
+++ b/server/service/endpoint_targets.go
@@ -21,7 +21,7 @@ type searchTargetsRequest struct {
 }
 
 type hostSearchResult struct {
-	hostResponse
+	HostResponse
 	DisplayText string `json:"display_text"`
 }
 
@@ -67,7 +67,7 @@ func makeSearchTargetsEndpoint(svc kolide.Service) endpoint.Endpoint {
 		for _, host := range results.Hosts {
 			targets.Hosts = append(targets.Hosts,
 				hostSearchResult{
-					hostResponse{
+					HostResponse{
 						Host:   host,
 						Status: host.Status(time.Now()),
 					},


### PR DESCRIPTION
This commit makes it easier to use the client package from outside of
Fleet by exporting the HostResponse type.