### PR TITLE
Remove extra mutex unlock in inmem.AddHostToPack

### DIFF
--- a/server/datastore/inmem/packs.go
+++ b/server/datastore/inmem/packs.go
@@ -126,7 +126,6 @@ func (d *Datastore) AddHostToPack(hid, pid uint) error {
 
 	for _, pt := range d.packTargets {
 		if pt.PackID == pid && pt.Target.Type == kolide.TargetHost && pt.Target.TargetID == hid {
-			d.mtx.Unlock()
 			return nil
 		}
 	}


### PR DESCRIPTION
On https://github.com/kolide/fleet/blob/master/server/datastore/inmem/packs.go#L129, there is an extra call to `d.mtx.Unlock()`, since there is a `defer` on https://github.com/kolide/fleet/blob/master/server/datastore/inmem/packs.go#L125, this Unlock actually causes a panic when hitting the `return` statement