### PR TITLE
Sanitize column names for order key in MySQL

### DIFF
--- a/server/datastore/mysql/mysql_test.go
+++ b/server/datastore/mysql/mysql_test.go
@@ -1,0 +1,26 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeColumn(t *testing.T) {
+	testCases := []struct {
+		input  string
+		output string
+	}{
+		{"foobar-column", "foobar-column"},
+		{"foobar_column", "foobar_column"},
+		{"foobar;column", "foobarcolumn"},
+		{"foobar#", "foobar"},
+		{"foobar*baz", "foobarbaz"},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.output, sanitizeColumn(tt.input))
+		})
+	}
+}


### PR DESCRIPTION
This adds a SQL injection prevention for a case in which we cannot use
parameters in the query.

It is not clear that this was possible to exploit. If it was possible,
it would have required a valid login to the Fleet server.