### PR TITLE
Fix firehose logging docs

### DIFF
--- a/docs/infrastructure/configuring-the-fleet-binary.md
+++ b/docs/infrastructure/configuring-the-fleet-binary.md
@@ -696,7 +696,7 @@ AWS region to use for Firehose connection
 
 This flag only has effect if `osquery_status_log_plugin` or `osquery_result_log_plugin` are set to `firehose`.
 
-If `firehose_access_key_id` and `firehose_secret_access_key` are ommitted, Fleet will try to use [AWS STS](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html) credentials.
+If `firehose_access_key_id` and `firehose_secret_access_key` are omitted, Fleet will try to use [AWS STS](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html) credentials.
 
 AWS access key ID to use for Firehose authentication.
 

--- a/docs/infrastructure/configuring-the-fleet-binary.md
+++ b/docs/infrastructure/configuring-the-fleet-binary.md
@@ -694,7 +694,9 @@ AWS region to use for Firehose connection
 
 ##### `firehose_access_key_id`
 
-This flag only has effect if `osquery_status_log_plugin` is set to `firehose`.
+This flag only has effect if `osquery_status_log_plugin` or `osquery_result_log_plugin` are set to `firehose`.
+
+If `firehose_access_key_id` and `firehose_secret_access_key` are ommitted, Fleet will try to use [AWS STS](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html) credentials.
 
 AWS access key ID to use for Firehose authentication.
 
@@ -709,7 +711,7 @@ AWS access key ID to use for Firehose authentication.
 
 ##### `firehose_secret_access_key`
 
-This flag only has effect if `osquery_status_log_plugin` is set to `firehose`.
+This flag only has effect if `osquery_status_log_plugin` or `osquery_result_log_plugin` are set to `firehose`.
 
 AWS secret access key to use for Firehose authentication.
 

--- a/docs/infrastructure/configuring-the-fleet-binary.md
+++ b/docs/infrastructure/configuring-the-fleet-binary.md
@@ -689,7 +689,7 @@ AWS region to use for Firehose connection
 
 	```
 	firehose:
-		region: us-west-2
+		region: ca-central-1
 	```
 
 ##### `firehose_access_key_id`

--- a/docs/infrastructure/configuring-the-fleet-binary.md
+++ b/docs/infrastructure/configuring-the-fleet-binary.md
@@ -689,7 +689,7 @@ AWS region to use for Firehose connection
 
 	```
 	firehose:
-		region: aws-east-2
+		region: us-west-2
 	```
 
 ##### `firehose_access_key_id`
@@ -704,7 +704,7 @@ AWS access key ID to use for Firehose authentication.
 
 	```
 	firehose:
-		access_key_id: aws-east-2
+		access_key_id: AKIAIOSFODNN7EXAMPLE
 	```
 
 ##### `firehose_secret_access_key`
@@ -719,7 +719,7 @@ AWS secret access key to use for Firehose authentication.
 
 	```
 	firehose:
-		secret_access_key: aws-east-2
+		secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 	```
 
 


### PR DESCRIPTION
This cleans up the AWS Kinesis Firehose logging documentation a little bit. I picked `ca-central-1` as the example AWS region since it has the [lowest carbon emissions][1] of any AWS region and perhaps the best bagels.

[1]: https://arxiv.org/pdf/1910.09700.pdf