### PR TITLE
Add capability to collect "additional" information from hosts

### DIFF
--- a/docs/cli/file-format.md
+++ b/docs/cli/file-format.md
@@ -244,7 +244,9 @@ spec:
   host_settings:
     # "additional" information to collect from hosts along with the host
     # details. This information will be updated at the same time as other host
-    # details and is returned by the API when host objects are returned.
+    # details and is returned by the API when host objects are returned. Users
+    # must take care to keep the data returned by these queries small in
+    # order to mitigate potential performance impacts on the Fleet server.
     additional_queries:
       time: select * from time
       macs: select mac from interface_details

--- a/docs/cli/file-format.md
+++ b/docs/cli/file-format.md
@@ -157,7 +157,7 @@ spec:
 
 ## Osquery Configuration Options
 
-The following file describes configuration options passed to the osquery instance. All other configuration data will be over-written by the application of this file.
+The following file describes options returned to osqueryd when it checks for configuration. See the [osquery documentation](https://osquery.readthedocs.io/en/stable/deployment/configuration/#options) for the available options. Existing options will be over-written by the application of this file.
 
 ```yaml
 apiVersion: v1
@@ -232,7 +232,7 @@ spec:
             3600: "SELECT total_seconds AS uptime FROM uptime"
 ```
 ## Fleet Configuration Options
-The following file describes configuration options applied to the Fleet instance.
+The following file describes configuration options applied to the Fleet server.
 
 ```yaml
 apiVersion: v1
@@ -241,6 +241,13 @@ spec:
   host_expiry_settings:
     host_expiry_enabled: true
     host_expiry_window: 10
+  host_settings:
+    # "additional" information to collect from hosts along with the host
+    # details. This information will be updated at the same time as other host
+    # details and is returned by the API when host objects are returned.
+    additional_queries:
+      time: select * from time
+      macs: select mac from interface_details
   org_info:
     org_logo_url: "https://example.org/logo.png"
     org_name: Example Org

--- a/server/datastore/datastore_app_test.go
+++ b/server/datastore/datastore_app_test.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/kolide/fleet/server/kolide"
@@ -52,4 +53,25 @@ func testOrgInfo(t *testing.T, ds kolide.Datastore) {
 	info4, err := ds.NewAppConfig(info3)
 	assert.Nil(t, err)
 	assert.Equal(t, info3, info4)
+}
+
+func testAdditionalQueries(t *testing.T, ds kolide.Datastore) {
+	additional := json.RawMessage("not valid json")
+	info := &kolide.AppConfig{
+		OrgName:           "Kolide",
+		OrgLogoURL:        "localhost:8080/logo.png",
+		AdditionalQueries: &additional,
+	}
+
+	_, err := ds.NewAppConfig(info)
+	assert.NotNil(t, err)
+
+	additional = json.RawMessage(`{}`)
+	info, err = ds.NewAppConfig(info)
+	assert.Nil(t, err)
+
+	additional = json.RawMessage(`{"foo": "bar"}`)
+	info, err = ds.NewAppConfig(info)
+	assert.Nil(t, err)
+	assert.JSONEq(t, `{"foo":"bar"}`, string(*info.AdditionalQueries))
 }

--- a/server/datastore/datastore_hosts_test.go
+++ b/server/datastore/datastore_hosts_test.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -72,12 +73,17 @@ func testSaveHosts(t *testing.T, ds kolide.Datastore) {
 		},
 	}
 
+	additionalJSON := json.RawMessage(`{"foobar": "bim"}`)
+	host.Additional = &additionalJSON
+
 	err = ds.SaveHost(host)
 	require.Nil(t, err)
 
 	host, err = ds.Host(host.ID)
 	require.Nil(t, err)
 	require.NotNil(t, host)
+	require.NotNil(t, host.Additional)
+	assert.Equal(t, additionalJSON, *host.Additional)
 	require.Equal(t, 2, len(host.NetworkInterfaces))
 	primaryNicID := host.NetworkInterfaces[0].ID
 	host.PrimaryNetworkInterfaceID = &primaryNicID

--- a/server/datastore/datastore_test.go
+++ b/server/datastore/datastore_test.go
@@ -94,4 +94,5 @@ var testFunctions = [...]func(*testing.T, kolide.Datastore){
 	testGetLabelSpec,
 	testLabelIDsByName,
 	testListLabelsForPack,
+	testHostAdditional,
 }

--- a/server/datastore/datastore_test.go
+++ b/server/datastore/datastore_test.go
@@ -17,6 +17,7 @@ func functionName(f func(*testing.T, kolide.Datastore)) string {
 
 var testFunctions = [...]func(*testing.T, kolide.Datastore){
 	testOrgInfo,
+	testAdditionalQueries,
 	testCreateInvite,
 	testInviteByEmail,
 	testInviteByToken,

--- a/server/datastore/mysql/app_configs.go
+++ b/server/datastore/mysql/app_configs.go
@@ -117,8 +117,8 @@ func (d *Datastore) SaveAppConfig(info *kolide.AppConfig) error {
       fim_interval,
       fim_file_accesses,
       host_expiry_enabled,
-	    host_expiry_window,
-	    live_query_disabled,
+      host_expiry_window,
+      live_query_disabled,
       additional_queries
     )
     VALUES( 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )
@@ -149,8 +149,8 @@ func (d *Datastore) SaveAppConfig(info *kolide.AppConfig) error {
       fim_interval = VALUES(fim_interval),
       fim_file_accesses = VALUES(fim_file_accesses),
       host_expiry_enabled = VALUES(host_expiry_enabled),
-   	  host_expiry_window = VALUES(host_expiry_window),
-  	  live_query_disabled = VALUES(live_query_disabled),
+      host_expiry_window = VALUES(host_expiry_window),
+      live_query_disabled = VALUES(live_query_disabled),
       additional_queries = VALUES(additional_queries)
     `
 

--- a/server/datastore/mysql/app_configs.go
+++ b/server/datastore/mysql/app_configs.go
@@ -117,10 +117,11 @@ func (d *Datastore) SaveAppConfig(info *kolide.AppConfig) error {
       fim_interval,
       fim_file_accesses,
       host_expiry_enabled,
-	  host_expiry_window,
-	  live_query_disabled
+	    host_expiry_window,
+	    live_query_disabled,
+      additional_queries
     )
-    VALUES( 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )
+    VALUES( 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )
     ON DUPLICATE KEY UPDATE
       org_name = VALUES(org_name),
       org_logo_url = VALUES(org_logo_url),
@@ -148,8 +149,9 @@ func (d *Datastore) SaveAppConfig(info *kolide.AppConfig) error {
       fim_interval = VALUES(fim_interval),
       fim_file_accesses = VALUES(fim_file_accesses),
       host_expiry_enabled = VALUES(host_expiry_enabled),
-	  host_expiry_window = VALUES(host_expiry_window),
-	  live_query_disabled = VALUES(live_query_disabled)
+   	  host_expiry_window = VALUES(host_expiry_window),
+  	  live_query_disabled = VALUES(live_query_disabled),
+      additional_queries = VALUES(additional_queries)
     `
 
 	_, err = d.db.Exec(insertStatement,
@@ -181,6 +183,7 @@ func (d *Datastore) SaveAppConfig(info *kolide.AppConfig) error {
 		info.HostExpiryEnabled,
 		info.HostExpiryWindow,
 		info.LiveQueryDisabled,
+		info.AdditionalQueries,
 	)
 
 	return err

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -172,7 +172,7 @@ func (d *Datastore) SaveHost(host *kolide.Host) error {
 			distributed_interval = ?,
 			config_tls_refresh = ?,
 			logger_tls_period = ?,
-			additional = ?
+			additional = COALESCE(?, additional)
 		WHERE id = ?
 	`
 	err := d.withRetryTxx(func(tx *sqlx.Tx) error {
@@ -489,7 +489,40 @@ func (d *Datastore) EnrollHost(osqueryHostID string, nodeKeySize int) (*kolide.H
 
 func (d *Datastore) AuthenticateHost(nodeKey string) (*kolide.Host, error) {
 	sqlStatement := `
-		SELECT *
+		SELECT
+			id,
+			osquery_host_id,
+			created_at,
+			updated_at,
+			deleted_at,
+			deleted,
+			detail_update_time,
+			node_key,
+			host_name,
+			uuid,
+			platform,
+			osquery_version,
+			os_version,
+			build,
+			platform_like,
+			code_name,
+			uptime,
+			physical_memory,
+			cpu_type,
+			cpu_subtype,
+			cpu_brand,
+			cpu_physical_cores,
+			cpu_logical_cores,
+			hardware_vendor,
+			hardware_model,
+			hardware_version,
+			hardware_serial,
+			computer_name,
+			primary_ip_id,
+			seen_time,
+			distributed_interval,
+			logger_tls_period,
+			config_tls_refresh
 		FROM hosts
 		WHERE node_key = ? AND NOT deleted
 		LIMIT 1

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -171,7 +171,8 @@ func (d *Datastore) SaveHost(host *kolide.Host) error {
 			seen_time = ?,
 			distributed_interval = ?,
 			config_tls_refresh = ?,
-			logger_tls_period = ?
+			logger_tls_period = ?,
+			additional = ?
 		WHERE id = ?
 	`
 	err := d.withRetryTxx(func(tx *sqlx.Tx) error {
@@ -203,7 +204,9 @@ func (d *Datastore) SaveHost(host *kolide.Host) error {
 			host.DistributedInterval,
 			host.ConfigTLSRefresh,
 			host.LoggerTLSPeriod,
-			host.ID)
+			host.Additional,
+			host.ID,
+		)
 		if err != nil {
 			return errors.Wrap(err, "executing main SQL statement")
 		}

--- a/server/datastore/mysql/migrations/tables/20200504120000_AddAdditionalToHosts.go
+++ b/server/datastore/mysql/migrations/tables/20200504120000_AddAdditionalToHosts.go
@@ -1,0 +1,35 @@
+package tables
+
+import (
+	"database/sql"
+
+	"github.com/pkg/errors"
+)
+
+func init() {
+	MigrationClient.AddMigration(Up_20200504120000, Down_20200504120000)
+}
+
+func Up_20200504120000(tx *sql.Tx) error {
+	_, err := tx.Exec(
+		"ALTER TABLE `hosts` " +
+			"ADD COLUMN `additional` JSON DEFAULT NULL;",
+	)
+	if err != nil {
+		errors.Wrap(err, "add additional column")
+	}
+
+	_, err = tx.Exec(
+		"ALTER TABLE `app_configs` " +
+			"ADD COLUMN `additional_queries` JSON DEFAULT NULL;",
+	)
+	if err != nil {
+		errors.Wrap(err, "add additional_queries column")
+	}
+	
+	return nil
+}
+
+func Down_20200504120000(tx *sql.Tx) error {
+	return nil
+}

--- a/server/kolide/app.go
+++ b/server/kolide/app.go
@@ -2,6 +2,7 @@ package kolide
 
 import (
 	"context"
+	"encoding/json"
 )
 
 // AppConfigStore contains method for saving and retrieving
@@ -143,6 +144,10 @@ type AppConfig struct {
 
 	// LiveQueryDisabled defines whether live queries are disabled.
 	LiveQueryDisabled bool `db:"live_query_disabled"`
+
+	// AdditionalQueries is the set of additional queries that should be run
+	// when collecting details from hosts.
+	AdditionalQueries *json.RawMessage `db:"additional_queries"`
 }
 
 // ModifyAppConfigRequest contains application configuration information
@@ -217,6 +222,7 @@ type AppConfigPayload struct {
 	ServerSettings     *ServerSettings      `json:"server_settings"`
 	SMTPSettings       *SMTPSettingsPayload `json:"smtp_settings"`
 	HostExpirySettings *HostExpirySettings  `json:"host_expiry_settings"`
+	HostSettings       *HostSettings        `json:"host_settings"`
 	// SMTPTest is a flag that if set will cause the server to test email configuration
 	SMTPTest *bool `json:"smtp_test,omitempty"`
 	// SSOSettings single sign settings
@@ -231,15 +237,19 @@ type OrgInfo struct {
 
 // ServerSettings contains general settings about the kolide App.
 type ServerSettings struct {
-	KolideServerURL    *string `json:"kolide_server_url,omitempty"`
-	EnrollSecret       *string `json:"osquery_enroll_secret,omitempty"`
-	LiveQueryDisabled  *bool   `json:"live_query_disabled,omitempty"`
+	KolideServerURL   *string `json:"kolide_server_url,omitempty"`
+	EnrollSecret      *string `json:"osquery_enroll_secret,omitempty"`
+	LiveQueryDisabled *bool   `json:"live_query_disabled,omitempty"`
 }
 
 // HostExpirySettings contains settings pertaining to automatic host expiry.
 type HostExpirySettings struct {
 	HostExpiryEnabled *bool `json:"host_expiry_enabled,omitempty"`
 	HostExpiryWindow  *int  `json:"host_expiry_window,omitempty"`
+}
+
+type HostSettings struct {
+	AdditionalQueries *json.RawMessage `json:"additional_queries"`
 }
 
 type OrderDirection int

--- a/server/kolide/hosts.go
+++ b/server/kolide/hosts.go
@@ -40,6 +40,10 @@ type HostStore interface {
 	Host(id uint) (*Host, error)
 	ListHosts(opt ListOptions) ([]*Host, error)
 	EnrollHost(osqueryHostId string, nodeKeySize int) (*Host, error)
+	// AuthenticateHost authenticates and returns host metadata by node key.
+	// This method should not return the host "additional" information as this
+	// is not typically necessary for the operations performed by the osquery
+	// endpoints.
 	AuthenticateHost(nodeKey string) (*Host, error)
 	MarkHostSeen(host *Host, t time.Time) error
 	SearchHosts(query string, omit ...uint) ([]*Host, error)

--- a/server/kolide/hosts.go
+++ b/server/kolide/hosts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"net"
 	"time"
 )
@@ -107,6 +108,7 @@ type Host struct {
 	DistributedInterval       uint                `json:"distributed_interval" db:"distributed_interval"`
 	ConfigTLSRefresh          uint                `json:"config_tls_refresh" db:"config_tls_refresh"`
 	LoggerTLSPeriod           uint                `json:"logger_tls_period" db:"logger_tls_period"`
+	Additional                *json.RawMessage    `json:"additional,omitempty" db:"additional"`
 }
 
 // HostSummary is a structure which represents a data summary about the total

--- a/server/service/endpoint_appconfig.go
+++ b/server/service/endpoint_appconfig.go
@@ -19,6 +19,7 @@ type appConfigResponse struct {
 	SMTPSettings       *kolide.SMTPSettingsPayload `json:"smtp_settings,omitempty"`
 	SSOSettings        *kolide.SSOSettingsPayload  `json:"sso_settings,omitempty"`
 	HostExpirySettings *kolide.HostExpirySettings  `json:"host_expiry_settings,omitempty"`
+	HostSettings       *kolide.HostSettings        `json:"host_settings,omitempty"`
 	Err                error                       `json:"error,omitempty"`
 }
 
@@ -70,6 +71,9 @@ func makeGetAppConfigEndpoint(svc kolide.Service) endpoint.Endpoint {
 			SMTPSettings:       smtpSettings,
 			SSOSettings:        ssoSettings,
 			HostExpirySettings: hostExpirySettings,
+			HostSettings: &kolide.HostSettings{
+				AdditionalQueries: config.AdditionalQueries,
+			},
 		}
 		return response, nil
 	}

--- a/server/service/service_appconfig.go
+++ b/server/service/service_appconfig.go
@@ -157,6 +157,12 @@ func appConfigFromAppConfigPayload(p kolide.AppConfigPayload, config kolide.AppC
 		}
 	}
 
+	if settings := p.HostSettings; settings != nil {
+		if settings.AdditionalQueries != nil {
+			config.AdditionalQueries = settings.AdditionalQueries
+		}
+	}
+
 	populateSMTP := func(p *kolide.SMTPSettingsPayload) {
 		if p.SMTPAuthenticationMethod != nil {
 			switch *p.SMTPAuthenticationMethod {


### PR DESCRIPTION
Additional information is collected when host details are updated using
the queries specified in the Fleet configuration. This additional
information is then available in the host API responses.

Thank you to [Secureframe](https://www.secureframe.com/) for sponsoring development of this feature.