### PR TITLE
Refactor `fleetctl get` subcommands so that they all have json and yaml output options

### DIFF
--- a/cmd/fleetctl/fleetctl.go
+++ b/cmd/fleetctl/fleetctl.go
@@ -28,19 +28,7 @@ func main() {
 		loginCommand(),
 		logoutCommand(),
 		queryCommand(),
-		cli.Command{
-			Name:  "get",
-			Usage: "Get/list resources",
-			Subcommands: []cli.Command{
-				getQueriesCommand(),
-				getPacksCommand(),
-				getLabelsCommand(),
-				getOptionsCommand(),
-				getHostsCommand(),
-				getEnrollSecretCommand(),
-				getAppConfigCommand(),
-			},
-		},
+		getCommand(),
 		cli.Command{
 			Name:  "config",
 			Usage: "Modify how and which Fleet server to connect to",

--- a/cmd/fleetctl/get.go
+++ b/cmd/fleetctl/get.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -13,6 +14,7 @@ import (
 
 const (
 	yamlFlagName        = "yaml"
+	jsonFlagName        = "json"
 	withQueriesFlagName = "with-queries"
 )
 
@@ -31,50 +33,172 @@ func defaultTable() *tablewriter.Table {
 func yamlFlag() cli.BoolFlag {
 	return cli.BoolFlag{
 		Name:  yamlFlagName,
-		Usage: "Output packs in yaml format",
+		Usage: "Output in yaml format",
 	}
 }
 
-func printQuery(query *kolide.QuerySpec, yamlSeparator bool) error {
+func jsonFlag() cli.BoolFlag {
+	return cli.BoolFlag{
+		Name:  jsonFlagName,
+		Usage: "Output in JSON format",
+	}
+}
+
+func printJSON(spec interface{}) error {
+	b, err := json.Marshal(spec)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s\n", b)
+	return nil
+}
+
+func printYaml(spec interface{}) error {
+	b, err := yaml.Marshal(spec)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("---\n%s", string(b))
+	return nil
+}
+
+func printLabel(c *cli.Context, label *kolide.LabelSpec) error {
+	spec := specGeneric{
+		Kind:    "label",
+		Version: kolide.ApiVersion,
+		Spec:    label,
+	}
+
+	var err error
+
+	if c.Bool(yamlFlagName) {
+		err = printYaml(spec)
+	} else {
+		err = printJSON(spec)
+	}
+
+	return err
+}
+
+func printQuery(c *cli.Context, query *kolide.QuerySpec) error {
 	spec := specGeneric{
 		Kind:    "query",
 		Version: kolide.ApiVersion,
 		Spec:    query,
 	}
 
-	b, err := yaml.Marshal(spec)
-	if err != nil {
-		return err
+	var err error
+
+	if c.Bool(yamlFlagName) {
+		err = printYaml(spec)
+	} else {
+		err = printJSON(spec)
 	}
 
-	sep := ""
-	if yamlSeparator {
-		sep = "---\n"
-	}
-
-	fmt.Printf("%s%s", sep, string(b))
-	return nil
+	return err
 }
 
-func printPack(pack *kolide.PackSpec, yamlSeparator bool) error {
+func printPack(c *cli.Context, pack *kolide.PackSpec) error {
 	spec := specGeneric{
 		Kind:    "pack",
 		Version: kolide.ApiVersion,
 		Spec:    pack,
 	}
 
-	b, err := yaml.Marshal(spec)
-	if err != nil {
-		return err
+	var err error
+
+	if c.Bool(yamlFlagName) {
+		err = printYaml(spec)
+	} else {
+		err = printJSON(spec)
 	}
 
-	sep := ""
-	if yamlSeparator {
-		sep = "---\n"
+	return err
+}
+
+func printOption(c *cli.Context, option *kolide.OptionsSpec) error {
+	spec := specGeneric{
+		Kind:    "option",
+		Version: kolide.ApiVersion,
+		Spec:    option,
 	}
 
-	fmt.Printf("%s%s", sep, string(b))
-	return nil
+	var err error
+
+	if c.Bool(yamlFlagName) {
+		err = printYaml(spec)
+	} else {
+		err = printJSON(spec)
+	}
+
+	return err
+}
+
+func printSecret(c *cli.Context, secret *kolide.EnrollSecretSpec) error {
+	spec := specGeneric{
+		Kind:    "enroll_secret",
+		Version: kolide.ApiVersion,
+		Spec:    secret,
+	}
+
+	var err error
+
+	if c.Bool(yamlFlagName) {
+		err = printYaml(spec)
+	} else {
+		err = printJSON(spec)
+	}
+
+	return err
+}
+
+func printHost(c *cli.Context, host *kolide.Host) error {
+	spec := specGeneric{
+		Kind:    "host",
+		Version: kolide.ApiVersion,
+		Spec:    host,
+	}
+
+	var err error
+
+	if c.Bool(yamlFlagName) {
+		err = printYaml(spec)
+	} else {
+		err = printJSON(spec)
+	}
+	return err
+}
+
+func printConfig(c *cli.Context, config *kolide.AppConfigPayload) error {
+	spec := specGeneric{
+		Kind:    "config",
+		Version: kolide.ApiVersion,
+		Spec:    config,
+	}
+	var err error
+
+	if c.Bool(yamlFlagName) {
+		err = printYaml(spec)
+	} else {
+		err = printJSON(spec)
+	}
+	return err
+}
+
+func getCommand() cli.Command {
+	return cli.Command{
+		Name:  "get",
+		Usage: "Get/list resources",
+		Subcommands: []cli.Command{
+			getQueriesCommand(),
+			getPacksCommand(),
+			getLabelsCommand(),
+			getOptionsCommand(),
+			getHostsCommand(),
+			getEnrollSecretCommand(),
+			getAppConfigCommand(),
+		},
+	}
 }
 
 func getQueriesCommand() cli.Command {
@@ -83,9 +207,10 @@ func getQueriesCommand() cli.Command {
 		Aliases: []string{"query", "q"},
 		Usage:   "List information about one or more queries",
 		Flags: []cli.Flag{
+			jsonFlag(),
+			yamlFlag(),
 			configFlag(),
 			contextFlag(),
-			yamlFlag(),
 		},
 		Action: func(c *cli.Context) error {
 			fleet, err := clientFromCLI(c)
@@ -102,49 +227,48 @@ func getQueriesCommand() cli.Command {
 					return errors.Wrap(err, "could not list queries")
 				}
 
-				if c.Bool(yamlFlagName) {
-					for _, query := range queries {
-						if err := printQuery(query, true); err != nil {
-							return errors.Wrap(err, "unable to print query")
-						}
-					}
-
-					return nil
-				}
-
 				if len(queries) == 0 {
 					fmt.Println("no queries found")
 					return nil
 				}
 
-				data := [][]string{}
+				if c.Bool(yamlFlagName) || c.Bool(jsonFlagName) {
+					for _, query := range queries {
+						if err := printQuery(c, query); err != nil {
+							return errors.Wrap(err, "unable to print query")
+						}
+					}
+				} else {
+					// Default to printing as a table
+					data := [][]string{}
 
-				for _, query := range queries {
-					data = append(data, []string{
-						query.Name,
-						query.Description,
-						query.Query,
-					})
+					for _, query := range queries {
+						data = append(data, []string{
+							query.Name,
+							query.Description,
+							query.Query,
+						})
+					}
+
+					table := defaultTable()
+					table.SetHeader([]string{"name", "description", "query"})
+					table.AppendBulk(data)
+					table.Render()
 				}
-
-				table := defaultTable()
-				table.SetHeader([]string{"name", "description", "query"})
-				table.AppendBulk(data)
-				table.Render()
-
-				return nil
-			} else {
-				query, err := fleet.GetQuery(name)
-				if err != nil {
-					return err
-				}
-
-				if err := printQuery(query, false); err != nil {
-					return errors.Wrap(err, "unable to print query")
-				}
-
 				return nil
 			}
+
+			query, err := fleet.GetQuery(name)
+			if err != nil {
+				return err
+			}
+
+			if err := printQuery(c, query); err != nil {
+				return errors.Wrap(err, "unable to print query")
+			}
+
+			return nil
+
 		},
 	}
 }
@@ -155,9 +279,10 @@ func getPacksCommand() cli.Command {
 		Aliases: []string{"pack", "p"},
 		Usage:   "List information about one or more packs",
 		Flags: []cli.Flag{
+			jsonFlag(),
+			yamlFlag(),
 			configFlag(),
 			contextFlag(),
-			yamlFlag(),
 			cli.BoolFlag{
 				Name:  withQueriesFlagName,
 				Usage: "Output queries included in pack(s) too",
@@ -198,7 +323,7 @@ func getPacksCommand() cli.Command {
 						continue
 					}
 
-					if err := printQuery(query, true); err != nil {
+					if err := printQuery(c, query); err != nil {
 						return errors.Wrap(err, "unable to print query")
 					}
 				}
@@ -215,7 +340,7 @@ func getPacksCommand() cli.Command {
 
 				if c.Bool(yamlFlagName) {
 					for _, pack := range packs {
-						if err := printPack(pack, true); err != nil {
+						if err := printPack(c, pack); err != nil {
 							return errors.Wrap(err, "unable to print pack")
 						}
 
@@ -246,20 +371,22 @@ func getPacksCommand() cli.Command {
 				table.Render()
 
 				return nil
-			} else {
-				pack, err := fleet.GetPack(name)
-				if err != nil {
-					return err
-				}
-
-				addQueries(pack)
-
-				if err := printPack(pack, shouldPrintQueries); err != nil {
-					return errors.Wrap(err, "unable to print pack")
-				}
-
-				return printQueries()
 			}
+
+			// Name was specified
+			pack, err := fleet.GetPack(name)
+			if err != nil {
+				return err
+			}
+
+			addQueries(pack)
+
+			if err := printPack(c, pack); err != nil {
+				return errors.Wrap(err, "unable to print pack")
+			}
+
+			return printQueries()
+
 		},
 	}
 }
@@ -270,9 +397,10 @@ func getLabelsCommand() cli.Command {
 		Aliases: []string{"label", "l"},
 		Usage:   "List information about one or more labels",
 		Flags: []cli.Flag{
+			jsonFlag(),
+			yamlFlag(),
 			configFlag(),
 			contextFlag(),
-			yamlFlag(),
 		},
 		Action: func(c *cli.Context) error {
 			fleet, err := clientFromCLI(c)
@@ -289,20 +417,9 @@ func getLabelsCommand() cli.Command {
 					return errors.Wrap(err, "could not list labels")
 				}
 
-				if c.Bool(yamlFlagName) {
+				if c.Bool(yamlFlagName) || c.Bool(jsonFlagName) {
 					for _, label := range labels {
-						spec := specGeneric{
-							Kind:    "label",
-							Version: kolide.ApiVersion,
-							Spec:    label,
-						}
-
-						b, err := yaml.Marshal(spec)
-						if err != nil {
-							return err
-						}
-
-						fmt.Printf("---\n%s", string(b))
+						printLabel(c, label)
 					}
 					return nil
 				}
@@ -312,6 +429,7 @@ func getLabelsCommand() cli.Command {
 					return nil
 				}
 
+				// Default to printing as a table
 				data := [][]string{}
 
 				for _, label := range labels {
@@ -329,27 +447,17 @@ func getLabelsCommand() cli.Command {
 				table.Render()
 
 				return nil
-			} else {
-				label, err := fleet.GetLabel(name)
-				if err != nil {
-					return err
-				}
-
-				spec := specGeneric{
-					Kind:    "label",
-					Version: kolide.ApiVersion,
-					Spec:    label,
-				}
-
-				b, err := yaml.Marshal(spec)
-				if err != nil {
-					return err
-				}
-
-				fmt.Print(string(b))
-
-				return nil
 			}
+
+			// Label name was specified
+			label, err := fleet.GetLabel(name)
+			if err != nil {
+				return err
+			}
+
+			printLabel(c, label)
+			return nil
+
 		},
 	}
 }
@@ -359,6 +467,8 @@ func getOptionsCommand() cli.Command {
 		Name:  "options",
 		Usage: "Retrieve the osquery configuration",
 		Flags: []cli.Flag{
+			jsonFlag(),
+			yamlFlag(),
 			configFlag(),
 			contextFlag(),
 		},
@@ -373,18 +483,11 @@ func getOptionsCommand() cli.Command {
 				return err
 			}
 
-			spec := specGeneric{
-				Kind:    "options",
-				Version: kolide.ApiVersion,
-				Spec:    options,
-			}
-
-			b, err := yaml.Marshal(spec)
+			err = printOption(c, options)
 			if err != nil {
 				return err
 			}
 
-			fmt.Print(string(b))
 			return nil
 		},
 	}
@@ -396,6 +499,8 @@ func getEnrollSecretCommand() cli.Command {
 		Aliases: []string{"enroll_secrets", "enroll-secret", "enroll-secrets"},
 		Usage:   "Retrieve the osquery enroll secrets",
 		Flags: []cli.Flag{
+			jsonFlag(),
+			yamlFlag(),
 			configFlag(),
 			contextFlag(),
 		},
@@ -410,18 +515,11 @@ func getEnrollSecretCommand() cli.Command {
 				return err
 			}
 
-			spec := specGeneric{
-				Kind:    "enroll_secret",
-				Version: kolide.ApiVersion,
-				Spec:    secrets,
-			}
-
-			b, err := yaml.Marshal(spec)
+			err = printSecret(c, secrets)
 			if err != nil {
 				return err
 			}
 
-			fmt.Print(string(b))
 			return nil
 		},
 	}
@@ -432,6 +530,8 @@ func getAppConfigCommand() cli.Command {
 		Name:  "config",
 		Usage: "Retrieve the Fleet configuration",
 		Flags: []cli.Flag{
+			jsonFlag(),
+			yamlFlag(),
 			configFlag(),
 			contextFlag(),
 		},
@@ -446,18 +546,11 @@ func getAppConfigCommand() cli.Command {
 				return err
 			}
 
-			spec := specGeneric{
-				Kind:    "config",
-				Version: kolide.ApiVersion,
-				Spec:    config,
-			}
-
-			b, err := yaml.Marshal(spec)
+			err = printConfig(c, config)
 			if err != nil {
 				return err
 			}
 
-			fmt.Print(string(b))
 			return nil
 		},
 	}
@@ -469,6 +562,8 @@ func getHostsCommand() cli.Command {
 		Aliases: []string{"host", "h"},
 		Usage:   "List information about one or more hosts",
 		Flags: []cli.Flag{
+			jsonFlag(),
+			yamlFlag(),
 			configFlag(),
 			contextFlag(),
 		},
@@ -488,6 +583,17 @@ func getHostsCommand() cli.Command {
 				return nil
 			}
 
+			if c.Bool(jsonFlagName) || c.Bool(yamlFlagName) {
+				for _, host := range hosts {
+					err = printHost(c, &host.Host)
+					if err != nil {
+						return err
+					}
+				}
+				return nil
+			}
+
+			// Default to printing as table
 			data := [][]string{}
 
 			for _, host := range hosts {

--- a/cmd/fleetctl/get.go
+++ b/cmd/fleetctl/get.go
@@ -71,10 +71,10 @@ func printLabel(c *cli.Context, label *kolide.LabelSpec) error {
 
 	var err error
 
-	if c.Bool(yamlFlagName) {
-		err = printYaml(spec)
-	} else {
+	if c.Bool(jsonFlagName) {
 		err = printJSON(spec)
+	} else {
+		err = printYaml(spec)
 	}
 
 	return err
@@ -89,10 +89,10 @@ func printQuery(c *cli.Context, query *kolide.QuerySpec) error {
 
 	var err error
 
-	if c.Bool(yamlFlagName) {
-		err = printYaml(spec)
-	} else {
+	if c.Bool(jsonFlagName) {
 		err = printJSON(spec)
+	} else {
+		err = printYaml(spec)
 	}
 
 	return err
@@ -107,10 +107,10 @@ func printPack(c *cli.Context, pack *kolide.PackSpec) error {
 
 	var err error
 
-	if c.Bool(yamlFlagName) {
-		err = printYaml(spec)
-	} else {
+	if c.Bool(jsonFlagName) {
 		err = printJSON(spec)
+	} else {
+		err = printYaml(spec)
 	}
 
 	return err
@@ -125,10 +125,10 @@ func printOption(c *cli.Context, option *kolide.OptionsSpec) error {
 
 	var err error
 
-	if c.Bool(yamlFlagName) {
-		err = printYaml(spec)
-	} else {
+	if c.Bool(jsonFlagName) {
 		err = printJSON(spec)
+	} else {
+		err = printYaml(spec)
 	}
 
 	return err
@@ -143,10 +143,10 @@ func printSecret(c *cli.Context, secret *kolide.EnrollSecretSpec) error {
 
 	var err error
 
-	if c.Bool(yamlFlagName) {
-		err = printYaml(spec)
-	} else {
+	if c.Bool(jsonFlagName) {
 		err = printJSON(spec)
+	} else {
+		err = printYaml(spec)
 	}
 
 	return err
@@ -161,11 +161,12 @@ func printHost(c *cli.Context, host *kolide.Host) error {
 
 	var err error
 
-	if c.Bool(yamlFlagName) {
-		err = printYaml(spec)
-	} else {
+	if c.Bool(jsonFlagName) {
 		err = printJSON(spec)
+	} else {
+		err = printYaml(spec)
 	}
+
 	return err
 }
 
@@ -177,11 +178,12 @@ func printConfig(c *cli.Context, config *kolide.AppConfigPayload) error {
 	}
 	var err error
 
-	if c.Bool(yamlFlagName) {
-		err = printYaml(spec)
-	} else {
+	if c.Bool(jsonFlagName) {
 		err = printJSON(spec)
+	} else {
+		err = printYaml(spec)
 	}
+
 	return err
 }
 


### PR DESCRIPTION
In this proposed patch all subcommands now have a new `--json` flag to allow for json output. They will default to using an ascii table if that was previously the default. 

Signed-off-by: grantseltzer <grantseltzer@gmail.com>