### PR TITLE
Log at debug level when configured

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -70,6 +70,11 @@ the way that the Fleet server works.
 				} else {
 					logger = kitlog.NewLogfmtLogger(output)
 				}
+				if config.Logging.Debug {
+					logger = level.NewFilter(logger, level.AllowDebug())
+				} else {
+					logger = level.NewFilter(logger, level.AllowInfo())
+				}
 				logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC)
 			}
 


### PR DESCRIPTION
We added debug/info log levels in #2225 but the configuration was not
actually used to set the level.