### PR TITLE
Fix fleetctl get options typo

### DIFF
--- a/cmd/fleetctl/apply.go
+++ b/cmd/fleetctl/apply.go
@@ -78,7 +78,7 @@ func specGroupFromBytes(b []byte) (*specGroup, error) {
 
 			var optionSpec *kolide.OptionsSpec
 			if err := yaml.Unmarshal(s.Spec, &optionSpec); err != nil {
-				return nil, errors.Wrap(err, "unmarshaling option spec")
+				return nil, errors.Wrap(err, "unmarshaling options spec")
 			}
 			specs.Options = optionSpec
 

--- a/cmd/fleetctl/get.go
+++ b/cmd/fleetctl/get.go
@@ -118,7 +118,7 @@ func printPack(c *cli.Context, pack *kolide.PackSpec) error {
 
 func printOption(c *cli.Context, option *kolide.OptionsSpec) error {
 	spec := specGeneric{
-		Kind:    "option",
+		Kind:    "options",
 		Version: kolide.ApiVersion,
 		Spec:    option,
 	}


### PR DESCRIPTION
* Fixes issue where `fleetctl get options` returns `option` (singular)
as `kind` instead of `options` (plural). This would cause `fleetctl
apply -f options.yml` to fail on options yaml generated by `fleetctl get
options` with this error: `unknown kind "option"`.