### PR TITLE
Fix string(int) issues for Go 1.15 compatibility

### DIFF
--- a/server/datastore/datastore_labels_test.go
+++ b/server/datastore/datastore_labels_test.go
@@ -19,7 +19,7 @@ func testLabels(t *testing.T, db kolide.Datastore) {
 	var host *kolide.Host
 	var err error
 	for i := 0; i < 10; i++ {
-		host, err = db.EnrollHost(string(i), string(i), "default")
+		host, err = db.EnrollHost(fmt.Sprint(i), fmt.Sprint(i), "default")
 		require.Nil(t, err, "enrollment should succeed")
 		hosts = append(hosts, *host)
 	}


### PR DESCRIPTION
`go vet` in Golang 1.15 does not allow type casting from int to string. More info in https://github.com/golang/go/issues/32479 and https://github.com/golang/go/issues/3939.

Example output:

```sh
$ make test
go vet ./...
# github.com/kolide/fleet/server/datastore
server/datastore/datastore_labels_test.go:22:29: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
server/datastore/datastore_labels_test.go:22:40: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
make: *** [lint-go] Error 2
```