### PR TITLE
Add compression option for filesystem logs when they're rotated

### DIFF
--- a/docs/infrastructure/configuring-the-fleet-binary.md
+++ b/docs/infrastructure/configuring-the-fleet-binary.md
@@ -700,6 +700,21 @@ rotated when files reach a size of 500 Mb or an age of 28 days.
      enable_log_rotation: true
   ```
 
+##### `filesystem_enable_log_compression`
+
+This flag only has effect if `filesystem_enable_log_rotation` is set to `true`.
+
+This flag will cause the rotated logs to be compressed with gzip.
+
+- Default value: `false`
+- Environment variable: `KOLIDE_FILESYSTEM_ENABLE_LOG_COMPRESSION`
+- Config file format:
+
+  ```
+  filesystem:
+     enable_log_compression: true
+  ```
+
 #### Firehose
 
 ##### `firehose_region`

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -17,18 +17,18 @@ const (
 
 // MysqlConfig defines configs related to MySQL
 type MysqlConfig struct {
-	Protocol      	string
-	Address       	string
-	Username      	string
-	Password      	string
-	Database      	string
-	TLSCert       	string `yaml:"tls_cert"`
-	TLSKey        	string `yaml:"tls_key"`
-	TLSCA         	string `yaml:"tls_ca"`
-	TLSServerName 	string `yaml:"tls_server_name"`
-	TLSConfig     	string `yaml:"tls_config"` //tls=customValue in DSN
-	MaxOpenConns  	int    `yaml:"max_open_conns"`
-	MaxIdleConns  	int    `yaml:"max_idle_conns"`
+	Protocol        string
+	Address         string
+	Username        string
+	Password        string
+	Database        string
+	TLSCert         string `yaml:"tls_cert"`
+	TLSKey          string `yaml:"tls_key"`
+	TLSCA           string `yaml:"tls_ca"`
+	TLSServerName   string `yaml:"tls_server_name"`
+	TLSConfig       string `yaml:"tls_config"` //tls=customValue in DSN
+	MaxOpenConns    int    `yaml:"max_open_conns"`
+	MaxIdleConns    int    `yaml:"max_idle_conns"`
 	ConnMaxLifetime int    `yaml:"conn_max_lifetime"`
 }
 
@@ -112,9 +112,10 @@ type PubSubConfig struct {
 
 // FilesystemConfig defines configs for the Filesystem logging plugin
 type FilesystemConfig struct {
-	StatusLogFile     string `yaml:"status_log_file"`
-	ResultLogFile     string `yaml:"result_log_file"`
-	EnableLogRotation bool   `yaml:"enable_log_rotation"`
+	StatusLogFile        string `yaml:"status_log_file"`
+	ResultLogFile        string `yaml:"result_log_file"`
+	EnableLogRotation    bool   `yaml:"enable_log_rotation"`
+	EnableLogCompression bool   `yaml:"enable_log_compression"`
 }
 
 // KolideConfig stores the application configuration. Each subcategory is
@@ -255,6 +256,8 @@ func (man Manager) addConfigs() {
 		"Log file path to use for result logs")
 	man.addConfigBool("filesystem.enable_log_rotation", false,
 		"Enable automatic rotation for osquery log files")
+	man.addConfigBool("filesystem.enable_log_compression", false,
+		"Enable compression for the rotated osquery log files")
 }
 
 // LoadConfig will load the config variables into a fully initialized
@@ -264,19 +267,19 @@ func (man Manager) LoadConfig() KolideConfig {
 
 	return KolideConfig{
 		Mysql: MysqlConfig{
-			Protocol:      		man.getConfigString("mysql.protocol"),
-			Address:       		man.getConfigString("mysql.address"),
-			Username:      		man.getConfigString("mysql.username"),
-			Password:      		man.getConfigString("mysql.password"),
-			Database:      		man.getConfigString("mysql.database"),
-			TLSCert:       		man.getConfigString("mysql.tls_cert"),
-			TLSKey:        		man.getConfigString("mysql.tls_key"),
-			TLSCA:         		man.getConfigString("mysql.tls_ca"),
-			TLSServerName: 		man.getConfigString("mysql.tls_server_name"),
-			TLSConfig:     		man.getConfigString("mysql.tls_config"),
-			MaxOpenConns:  		man.getConfigInt("mysql.max_open_conns"),
-			MaxIdleConns:  		man.getConfigInt("mysql.max_idle_conns"),
-			ConnMaxLifetime:	man.getConfigInt("mysql.conn_max_lifetime"),
+			Protocol:        man.getConfigString("mysql.protocol"),
+			Address:         man.getConfigString("mysql.address"),
+			Username:        man.getConfigString("mysql.username"),
+			Password:        man.getConfigString("mysql.password"),
+			Database:        man.getConfigString("mysql.database"),
+			TLSCert:         man.getConfigString("mysql.tls_cert"),
+			TLSKey:          man.getConfigString("mysql.tls_key"),
+			TLSCA:           man.getConfigString("mysql.tls_ca"),
+			TLSServerName:   man.getConfigString("mysql.tls_server_name"),
+			TLSConfig:       man.getConfigString("mysql.tls_config"),
+			MaxOpenConns:    man.getConfigInt("mysql.max_open_conns"),
+			MaxIdleConns:    man.getConfigInt("mysql.max_idle_conns"),
+			ConnMaxLifetime: man.getConfigInt("mysql.conn_max_lifetime"),
 		},
 		Redis: RedisConfig{
 			Address:  man.getConfigString("redis.address"),
@@ -332,9 +335,10 @@ func (man Manager) LoadConfig() KolideConfig {
 			ResultTopic: man.getConfigString("pubsub.result_topic"),
 		},
 		Filesystem: FilesystemConfig{
-			StatusLogFile:     man.getConfigString("filesystem.status_log_file"),
-			ResultLogFile:     man.getConfigString("filesystem.result_log_file"),
-			EnableLogRotation: man.getConfigBool("filesystem.enable_log_rotation"),
+			StatusLogFile:        man.getConfigString("filesystem.status_log_file"),
+			ResultLogFile:        man.getConfigString("filesystem.result_log_file"),
+			EnableLogRotation:    man.getConfigBool("filesystem.enable_log_rotation"),
+			EnableLogCompression: man.getConfigBool("filesystem.enable_log_compression"),
 		},
 	}
 }

--- a/server/logging/filesystem.go
+++ b/server/logging/filesystem.go
@@ -20,10 +20,10 @@ type filesystemLogWriter struct {
 	writer io.WriteCloser
 }
 
-// NewFilesystemLogWriter creates a log file for osquery status/result logs the
-// logFile can be rotated by sending a `SIGHUP` signal to kolide if
+// NewFilesystemLogWriter creates a log file for osquery status/result logs.
+// The logFile can be rotated by sending a `SIGHUP` signal to Fleet if
 // enableRotation is true
-func NewFilesystemLogWriter(path string, appLogger log.Logger, enableRotation bool) (*filesystemLogWriter, error) {
+func NewFilesystemLogWriter(path string, appLogger log.Logger, enableRotation bool, enableCompression bool) (*filesystemLogWriter, error) {
 	if enableRotation {
 		// Use lumberjack logger that supports rotation
 		osquerydLogger := &lumberjack.Logger{
@@ -31,6 +31,7 @@ func NewFilesystemLogWriter(path string, appLogger log.Logger, enableRotation bo
 			MaxSize:    500, // megabytes
 			MaxBackups: 3,
 			MaxAge:     28, //days
+			Compress:   enableCompression,
 		}
 		appLogger = log.With(appLogger, "component", "osqueryd-logger")
 		sig := make(chan os.Signal)

--- a/server/logging/filesystem_test.go
+++ b/server/logging/filesystem_test.go
@@ -19,7 +19,7 @@ func TestFilesystemLogger(t *testing.T) {
 	tempPath, err := ioutil.TempDir("", "test")
 	require.Nil(t, err)
 	fileName := path.Join(tempPath, "filesystemLogWriter")
-	lgr, err := NewFilesystemLogWriter(fileName, log.NewNopLogger(), false)
+	lgr, err := NewFilesystemLogWriter(fileName, log.NewNopLogger(), false, false)
 	require.Nil(t, err)
 	defer os.Remove(fileName)
 
@@ -66,7 +66,7 @@ func BenchmarkFilesystemLogger(b *testing.B) {
 		b.Fatal("temp dir failed", err)
 	}
 	fileName := path.Join(tempPath, "filesystemLogWriter")
-	lgr, err := NewFilesystemLogWriter(fileName, log.NewNopLogger(), false)
+	lgr, err := NewFilesystemLogWriter(fileName, log.NewNopLogger(), false, false)
 	if err != nil {
 		b.Fatal("new failed ", err)
 	}
@@ -93,13 +93,21 @@ func BenchmarkFilesystemLogger(b *testing.B) {
 }
 
 func BenchmarkLumberjack(b *testing.B) {
+	benchLumberjack(b, false)
+}
+
+func BenchmarkLumberjackWithCompression(b *testing.B) {
+	benchLumberjack(b, true)
+}
+
+func benchLumberjack(b *testing.B, compression bool) {
 	ctx := context.Background()
 	tempPath, err := ioutil.TempDir("", "test")
 	if err != nil {
 		b.Fatal("temp dir failed", err)
 	}
 	fileName := path.Join(tempPath, "lumberjack")
-	lgr, err := NewFilesystemLogWriter(fileName, log.NewNopLogger(), true)
+	lgr, err := NewFilesystemLogWriter(fileName, log.NewNopLogger(), true, compression)
 	if err != nil {
 		b.Fatal("new failed ", err)
 	}

--- a/server/logging/logging.go
+++ b/server/logging/logging.go
@@ -29,6 +29,7 @@ func New(config config.KolideConfig, logger log.Logger) (*OsqueryLogger, error) 
 			config.Filesystem.StatusLogFile,
 			logger,
 			config.Filesystem.EnableLogRotation,
+			config.Filesystem.EnableLogCompression,
 		)
 		if err != nil {
 			return nil, errors.Wrap(err, "create filesystem status logger")
@@ -69,6 +70,7 @@ func New(config config.KolideConfig, logger log.Logger) (*OsqueryLogger, error) 
 			config.Filesystem.ResultLogFile,
 			logger,
 			config.Filesystem.EnableLogRotation,
+			config.Filesystem.EnableLogCompression,
 		)
 		if err != nil {
 			return nil, errors.Wrap(err, "create filesystem result logger")

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -24,7 +24,7 @@ func TestRotateLoggerSIGHUP(t *testing.T) {
 	require.Nil(t, err)
 	defer os.Remove(f.Name())
 
-	logFile, err := logging.NewFilesystemLogWriter(f.Name(), log.NewNopLogger(), true)
+	logFile, err := logging.NewFilesystemLogWriter(f.Name(), log.NewNopLogger(), true, false)
 	require.Nil(t, err)
 
 	// write a log line


### PR DESCRIPTION
This adds support for compressing the rotated log files if the `filesystem` logger plugin is set.

This should address the first portion of #2180.