### PR TITLE
Add osquery_version field to `fleetctl get hosts`

### DIFF
--- a/cmd/fleetctl/get.go
+++ b/cmd/fleetctl/get.go
@@ -616,12 +616,13 @@ func getHostsCommand() cli.Command {
 						host.Host.UUID,
 						host.DisplayText,
 						host.Host.Platform,
+						host.OsqueryVersion,
 						string(host.Status),
 					})
 				}
 
 				table := defaultTable()
-				table.SetHeader([]string{"uuid", "hostname", "platform", "status"})
+				table.SetHeader([]string{"uuid", "hostname", "platform", "osquery_version", "status"})
 				table.AppendBulk(data)
 				table.Render()
 			} else {


### PR DESCRIPTION
This change makes the `fleetctl get hosts` command include the osquery version in the output. It also fixes another string(int) compatibility issue with Go 1.15. 

Fixes https://github.com/kolide/fleet/issues/2301