### PR TITLE
Add -L option to curl

### DIFF
--- a/docs/infrastructure/installing-fleet.md
+++ b/docs/infrastructure/installing-fleet.md
@@ -28,7 +28,7 @@ For more information on using Fleet, refer to the [Configuring The Fleet Binary]
 Download the latest raw Fleet binaries:
 
 ```
-curl -O https://github.com/kolide/fleet/releases/latest/download/fleet.zip
+curl -LO https://github.com/kolide/fleet/releases/latest/download/fleet.zip
 ```
 
 Unzip the binaries for your platform:


### PR DESCRIPTION
The example in the README won't follow the github redirect without `-L`, so the example as is will download an html file instead of the actual `fleet.zip`. This fixes that.