### PR TITLE
Add redis use_tls cfg

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -176,7 +176,7 @@ the way that the Fleet server works.
 				}
 			}
 
-			redisPool := pubsub.NewRedisPool(config.Redis.Address, config.Redis.Password, config.Redis.Database)
+			redisPool := pubsub.NewRedisPool(config.Redis.Address, config.Redis.Password, config.Redis.Database, config.Redis.UseTLS)
 			resultStore := pubsub.NewRedisQueryResults(redisPool)
 			liveQueryStore := live_query.NewRedisLiveQuery(redisPool)
 			ssoSessionStore := sso.NewSessionStore(redisPool)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -37,7 +37,7 @@ type RedisConfig struct {
 	Address  string
 	Password string
 	Database int
-	UseTLS   bool
+	UseTLS   bool `yaml:"use_tls"`
 }
 
 const (

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -37,6 +37,7 @@ type RedisConfig struct {
 	Address  string
 	Password string
 	Database int
+	UseTLS   bool
 }
 
 const (
@@ -182,6 +183,7 @@ func (man Manager) addConfigs() {
 		"Redis server password (prefer env variable for security)")
 	man.addConfigInt("redis.database", 0,
 		"Redis server database number")
+	man.addConfigBool("redis.use_tls", false, "Redis server enable TLS")
 
 	// Server
 	man.addConfigString("server.address", "0.0.0.0:8080",
@@ -309,6 +311,7 @@ func (man Manager) LoadConfig() KolideConfig {
 			Address:  man.getConfigString("redis.address"),
 			Password: man.getConfigString("redis.password"),
 			Database: man.getConfigInt("redis.database"),
+			UseTLS:   man.getConfigBool("redis.use_tls"),
 		},
 		Server: ServerConfig{
 			Address:    man.getConfigString("server.address"),

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -47,12 +47,7 @@ func TestConfigRoundtrip(t *testing.T) {
 			case int:
 				key_v.SetInt(int64(conf_index*100 + key_index))
 			case bool:
-				switch conf_v.Type().Field(key_index).Name {
-				case "UseTLS":
-					key_v.SetBool(false)
-				default:
-					key_v.SetBool(true)
-				}
+				key_v.SetBool(true)
 			case time.Duration:
 				d := time.Duration(conf_index*100 + key_index)
 				key_v.Set(reflect.ValueOf(d))

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -47,7 +47,12 @@ func TestConfigRoundtrip(t *testing.T) {
 			case int:
 				key_v.SetInt(int64(conf_index*100 + key_index))
 			case bool:
-				key_v.SetBool(true)
+				switch conf_v.Type().Field(key_index).Name {
+				case "UseTLS":
+					key_v.SetBool(false)
+				default:
+					key_v.SetBool(true)
+				}
 			case time.Duration:
 				d := time.Duration(conf_index*100 + key_index)
 				key_v.Set(reflect.ValueOf(d))

--- a/server/live_query/redis_live_query_test.go
+++ b/server/live_query/redis_live_query_test.go
@@ -30,13 +30,14 @@ func setupRedisLiveQuery(t *testing.T) (store *redisLiveQuery, teardown func()) 
 		addr     = "127.0.0.1:6379"
 		password = ""
 		database = 0
+		useTLS   = false
 	)
 
 	if a, ok := os.LookupEnv("REDIS_PORT_6379_TCP_ADDR"); ok {
 		addr = fmt.Sprintf("%s:6379", a)
 	}
 
-	store = NewRedisLiveQuery(pubsub.NewRedisPool(addr, password, database))
+	store = NewRedisLiveQuery(pubsub.NewRedisPool(addr, password, database, useTLS))
 
 	_, err := store.pool.Get().Do("PING")
 	require.NoError(t, err)

--- a/server/pubsub/query_results_test.go
+++ b/server/pubsub/query_results_test.go
@@ -65,13 +65,14 @@ func setupRedis(t *testing.T) (store *redisQueryResults, teardown func()) {
 		addr     = "127.0.0.1:6379"
 		password = ""
 		database = 0
+		useTLS   = false
 	)
 
 	if a, ok := os.LookupEnv("REDIS_PORT_6379_TCP_ADDR"); ok {
 		addr = fmt.Sprintf("%s:6379", a)
 	}
 
-	store = NewRedisQueryResults(NewRedisPool(addr, password, database))
+	store = NewRedisQueryResults(NewRedisPool(addr, password, database, useTLS))
 
 	_, err := store.pool.Get().Do("PING")
 	require.Nil(t, err)

--- a/server/pubsub/redis_query_results.go
+++ b/server/pubsub/redis_query_results.go
@@ -20,12 +20,12 @@ var _ kolide.QueryResultStore = &redisQueryResults{}
 
 // NewRedisPool creates a Redis connection pool using the provided server
 // address, password and database.
-func NewRedisPool(server, password string, database int) *redis.Pool {
+func NewRedisPool(server, password string, database int, useTLS bool) *redis.Pool {
 	return &redis.Pool{
 		MaxIdle:     3,
 		IdleTimeout: 240 * time.Second,
 		Dial: func() (redis.Conn, error) {
-			c, err := redis.Dial("tcp", server, redis.DialDatabase(database))
+			c, err := redis.Dial("tcp", server, redis.DialDatabase(database), redis.DialUseTLS(useTLS))
 			if err != nil {
 				return nil, err
 			}

--- a/server/sso/session_store_test.go
+++ b/server/sso/session_store_test.go
@@ -18,12 +18,13 @@ func newPool(t *testing.T) *redis.Pool {
 			addr     = "127.0.0.1:6379"
 			password = ""
 			database = 0
+			useTLS   = false
 		)
 		if a, ok := os.LookupEnv("REDIS_PORT_6379_TCP_ADDR"); ok {
 			addr = fmt.Sprintf("%s:6379", a)
 		}
 
-		p := pubsub.NewRedisPool(addr, password, database)
+		p := pubsub.NewRedisPool(addr, password, database, useTLS)
 		_, err := p.Get().Do("PING")
 		require.Nil(t, err)
 		return p


### PR DESCRIPTION
Adding config parameter 'redis.use_tls' to enable tls communications with redis e.g. AWS ElastiCache

Closes #2247