### PR TITLE
Add DeleteHost func to service pkg

### DIFF
--- a/server/service/client_hosts.go
+++ b/server/service/client_hosts.go
@@ -3,8 +3,9 @@ package service
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"net/http"
+
+	"github.com/pkg/errors"
 )
 
 // GetHosts retrieves the list of all Hosts

--- a/server/service/client_hosts.go
+++ b/server/service/client_hosts.go
@@ -2,9 +2,9 @@ package service
 
 import (
 	"encoding/json"
-	"net/http"
-
+	"fmt"
 	"github.com/pkg/errors"
+	"net/http"
 )
 
 // GetHosts retrieves the list of all Hosts
@@ -60,4 +60,39 @@ func (c *Client) HostByIdentifier(identifier string) (*HostResponse, error) {
 	}
 
 	return responseBody.Host, nil
+}
+
+// DeleteHost deletes the host with the matching id.
+func (c *Client) DeleteHost(id uint) error {
+	verb := "DELETE"
+	path := fmt.Sprintf("/api/v1/kolide/hosts/%d", id)
+	response, err := c.AuthenticatedDo(verb, path, nil)
+	if err != nil {
+		return errors.Wrapf(err, "%s %s", verb, path)
+	}
+	defer response.Body.Close()
+
+	switch response.StatusCode {
+	case http.StatusNotFound:
+		return notFoundErr{}
+	}
+	if response.StatusCode != http.StatusOK {
+		return errors.Errorf(
+			"delete host received status %d %s",
+			response.StatusCode,
+			extractServerErrorText(response.Body),
+		)
+	}
+
+	var responseBody deleteHostResponse
+	err = json.NewDecoder(response.Body).Decode(&responseBody)
+	if err != nil {
+		return errors.Wrap(err, "decode delete host response")
+	}
+
+	if responseBody.Err != nil {
+		return errors.Errorf("delete host: %s", responseBody.Err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
We have some automation that deletes hosts matching some predefined filters to avoid a build up of dead hosts.

The client struct doesn't currently expose a function for calling the delete api. This PR adds such a function and matches the style of the existing delete functions for other kolide objects.