### PR TITLE
Log host identifier in EnrollAgent service logging

### DIFF
--- a/server/service/logging_osquery.go
+++ b/server/service/logging_osquery.go
@@ -21,6 +21,7 @@ func (mw loggingMiddleware) EnrollAgent(ctx context.Context, enrollSecret string
 			"method", "EnrollAgent",
 			"ip_addr", ctx.Value(kithttp.ContextKeyRequestRemoteAddr).(string),
 			"x_for_ip_addr", ctx.Value(kithttp.ContextKeyRequestXForwardedFor).(string),
+			"host_identifier", hostIdentifier,
 			"err", err,
 			"took", time.Since(begin),
 		)


### PR DESCRIPTION
This can help identify circumstances in which multiple hosts are
providing the same identifier and clobbering the node key for each
other.