### PR TITLE
Add explicit int64 for parsing physical_memory column

### DIFF
--- a/server/kolide/hosts.go
+++ b/server/kolide/hosts.go
@@ -111,7 +111,7 @@ type Host struct {
 	PlatformLike     string        `json:"platform_like" db:"platform_like"`
 	CodeName         string        `json:"code_name" db:"code_name"`
 	Uptime           time.Duration `json:"uptime"`
-	PhysicalMemory   int           `json:"memory" sql:"type:bigint" db:"physical_memory"`
+	PhysicalMemory   int64         `json:"memory" sql:"type:bigint" db:"physical_memory"`
 	// system_info fields
 	CPUType          string `json:"cpu_type" db:"cpu_type"`
 	CPUSubtype       string `json:"cpu_subtype" db:"cpu_subtype"`

--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -411,7 +411,7 @@ var detailQueries = map[string]struct {
 			}
 
 			var err error
-			host.PhysicalMemory, err = strconv.Atoi(emptyToZero(rows[0]["physical_memory"]))
+			host.PhysicalMemory, err = strconv.ParseInt(emptyToZero(rows[0]["physical_memory"]), 10, 64)
 			if err != nil {
 				return err
 			}

--- a/server/service/service_osquery_test.go
+++ b/server/service/service_osquery_test.go
@@ -650,7 +650,7 @@ func TestDetailQueriesWithEmptyStrings(t *testing.T) {
 	assert.Equal(t, "1.8.2", gotHost.OsqueryVersion)
 
 	// system_info
-	assert.Equal(t, 17179869184, gotHost.PhysicalMemory)
+	assert.Equal(t, int64(17179869184), gotHost.PhysicalMemory)
 	assert.Equal(t, "computer.local", gotHost.HostName)
 	assert.Equal(t, "uuid", gotHost.UUID)
 
@@ -820,7 +820,7 @@ func TestDetailQueries(t *testing.T) {
 	assert.Equal(t, "1.8.2", gotHost.OsqueryVersion)
 
 	// system_info
-	assert.Equal(t, 17179869184, gotHost.PhysicalMemory)
+	assert.Equal(t, int64(17179869184), gotHost.PhysicalMemory)
 	assert.Equal(t, "computer.local", gotHost.HostName)
 	assert.Equal(t, "uuid", gotHost.UUID)
 


### PR DESCRIPTION
Addresses an error when Fleet is compiled for a 32-bit architecture.

May not be comprehensive of all related errors.

Fixes #2314.