### PR TITLE
Fix cleanup of orphaned queries

### DIFF
--- a/server/pubsub/inmem_query_results.go
+++ b/server/pubsub/inmem_query_results.go
@@ -49,13 +49,13 @@ func (im *inmemQueryResults) WriteResult(result kolide.DistributedQueryResult) e
 	return nil
 }
 
-func (im *inmemQueryResults) ReadChannel(ctx context.Context, query kolide.DistributedQueryCampaign) (<-chan interface{}, error) {
-	channel := im.getChannel(query.ID)
+func (im *inmemQueryResults) ReadChannel(ctx context.Context, campaign kolide.DistributedQueryCampaign) (<-chan interface{}, error) {
+	channel := im.getChannel(campaign.ID)
 	go func() {
 		<-ctx.Done()
 		close(channel)
 		im.channelMutex.Lock()
-		delete(im.resultChannels, query.ID)
+		delete(im.resultChannels, campaign.ID)
 		im.channelMutex.Unlock()
 	}()
 	return channel, nil


### PR DESCRIPTION
The expiration logic was incorrect leading to queries not being cleaned
up properly. Tests added for the whole subroutine.

Fixes #2302