### PR TITLE
Clarify and explicitly order enroll host transaction

### DIFF
--- a/server/datastore/datastore_hosts_test.go
+++ b/server/datastore/datastore_hosts_test.go
@@ -179,14 +179,20 @@ func testListHost(t *testing.T, ds kolide.Datastore) {
 
 func testEnrollHost(t *testing.T, ds kolide.Datastore) {
 	test.AddAllHostsLabel(t, ds)
-	var hosts []*kolide.Host
+	enrollSecretName := "default"
 	for _, tt := range enrollTests {
-		h, err := ds.EnrollHost(tt.uuid, tt.nodeKey, "default")
+		h, err := ds.EnrollHost(tt.uuid, tt.nodeKey, enrollSecretName)
 		require.Nil(t, err)
 
-		hosts = append(hosts, h)
 		assert.Equal(t, tt.uuid, h.OsqueryHostID)
-		assert.NotEmpty(t, h.NodeKey)
+		assert.Equal(t, tt.nodeKey, h.NodeKey)
+		assert.Equal(t, enrollSecretName, h.EnrollSecretName)
+
+		h, err = ds.EnrollHost(tt.uuid, tt.nodeKey+"new", enrollSecretName+"new")
+		require.Nil(t, err)
+		assert.Equal(t, tt.uuid, h.OsqueryHostID)
+		assert.Equal(t, tt.nodeKey+"new", h.NodeKey)
+		assert.Equal(t, enrollSecretName+"new", h.EnrollSecretName)
 	}
 }
 

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -238,7 +238,7 @@ func (d *Datastore) EnrollHost(osqueryHostID, nodeKey, secretName string) (*koli
 		zeroTime := time.Unix(0, 0).Add(24 * time.Hour)
 
 		var id int64
-		err := tx.Get(&id, `SELECT id FROM hosts WHERE osquery_host_id = ?`, osqueryHostID)
+		err := tx.Get(&id, `SELECT id FROM hosts WHERE osquery_host_id = ? FOR UPDATE`, osqueryHostID)
 		if err != nil {
 			// Create new host record
 			sqlInsert := `


### PR DESCRIPTION
Previously this used an implicit transaction with `INSERT ... ON
DUPLICATE KEY UPDATE`. Now we make the transaction explicit with the
hopes of resolving some deadlock issues users encountered at very high
scale.

These issues are possibly root-caused by misconfiguration of osquery
resulting in copied host identifiers, making this change less relevant. I
still believe it is worth being more explicit about this transaction.
