### PR TITLE
docker-compose QoL improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   mysql:
     image: mysql:5.7
     volumes:
-      - .:/tmp
+      - mysql-persistent-volume:/tmp
     command: mysqld --datadir=/tmp/mysqldata --slow_query_log=1 --log_output=TABLE --log-queries-not-using-indexes --event-scheduler=ON
     environment: &mysql-default-environment
       MYSQL_ROOT_PASSWORD: toor
@@ -44,3 +44,6 @@ services:
       - /var/run:/var/run:rw
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
+
+volumes:
+  mysql-persistent-volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 version: '2'
 services:
   mysql:
@@ -5,7 +6,7 @@ services:
     volumes:
       - .:/tmp
     command: mysqld --datadir=/tmp/mysqldata --slow_query_log=1 --log_output=TABLE --log-queries-not-using-indexes --event-scheduler=ON
-    environment:
+    environment: &mysql-default-environment
       MYSQL_ROOT_PASSWORD: toor
       MYSQL_DATABASE: kolide
       MYSQL_USER: kolide
@@ -17,11 +18,7 @@ services:
     image: mysql:5.7
     command: mysqld --datadir=/tmpfs  --slow_query_log=1 --log_output=TABLE --log-queries-not-using-indexes --event-scheduler=ON
     tmpfs: /tmpfs
-    environment:
-      MYSQL_ROOT_PASSWORD: toor
-      MYSQL_DATABASE: kolide
-      MYSQL_USER: kolide
-      MYSQL_PASSWORD: kolide
+    environment: *mysql-default-environment
     ports:
       - "3307:3306"
 

--- a/tools/osquery/README.md
+++ b/tools/osquery/README.md
@@ -25,6 +25,9 @@ Set the environment variable `ENROLL_SECRET` to the value of your Fleet enroll s
 
 (Optionally) Set `KOLIDE_OSQUERY_VERSION` if you want to run an osquery container besides `latest`.
 
+(Optionally) Set `FLEET_SERVER` if you want to connect to a fleet server
+besides `host.docker.internal:8080`.
+
 ### Running osqueryd
 
 The osqueryd instances are configured to use the TLS plugins at `host.docker.internal:8080`. Using the `example_osquery.flags` in this directory should configure Fleet with the appropriate settings for these `osqueryd` containers to connect.

--- a/tools/osquery/README.md
+++ b/tools/osquery/README.md
@@ -32,10 +32,18 @@ besides `host.docker.internal:8080`.
 
 The osqueryd instances are configured to use the TLS plugins at `host.docker.internal:8080`. Using the `example_osquery.flags` in this directory should configure Fleet with the appropriate settings for these `osqueryd` containers to connect.
 
-To start one instance each of Centos and Ubuntu `osqueryd`, use:
+To start one instance each of Centos 6, Centos 7, Ubuntu 14, and Ubuntu 16
+`osqueryd`, use:
 
 ```
 docker-compose up
+```
+
+Linux users should use the overrides (which add DNS entries for
+`host.docker.internal` based on the `DOCKER_HOST` env var):
+
+```
+docker-compose -f docker-compose.yml -f docker-compose.linux-overrides.yml up
 ```
 
 The logs will be displayed on the host shell. Note that `docker-compose up` will reuse containers (so the state of `osqueryd` will be maintained across calls). To remove the containers and start from a fresh state on the next call to `up`, use:

--- a/tools/osquery/docker-compose.linux-overrides.yml
+++ b/tools/osquery/docker-compose.linux-overrides.yml
@@ -1,0 +1,21 @@
+---
+version: '2'
+
+x-default-settings:
+  extra_hosts: &linux-extra-hosts
+    # Add host.docker.internal record to /etc/hosts of the containers. This is
+    # added on Docker for Mac by default, but needs to be added by Linux users.
+    - "host.docker.internal:${DOCKER_HOST:-172.17.0.1}"
+
+services:
+  ubuntu14-osquery:
+    extra_hosts: *linux-extra-hosts
+
+  ubuntu16-osquery:
+    extra_hosts: *linux-extra-hosts
+
+  centos7-osquery:
+    extra_hosts: *linux-extra-hosts
+
+  centos6-osquery:
+    extra_hosts: *linux-extra-hosts

--- a/tools/osquery/docker-compose.yml
+++ b/tools/osquery/docker-compose.yml
@@ -1,55 +1,37 @@
-
+---
 version: '2'
 
 services:
   ubuntu14-osquery:
     image: "kolide/osquery:${KOLIDE_OSQUERY_VERSION}"
-    volumes:
+    volumes: &default-volumes
       - ./kolide.crt:/etc/osquery/kolide.crt
       - ./example_osquery.flags:/etc/osquery/osquery.flags
-    environment:
-      ENROLL_SECRET: "${ENROLL_SECRET}"
-    command: osqueryd --flagfile=/etc/osquery/osquery.flags
-    ulimits:
+    environment: &default-environment
+      ENROLL_SECRET: "${ENROLL_SECRET:?ENROLL_SECRET must be set for server authentication}"
+    command: &default-command osqueryd --flagfile=/etc/osquery/osquery.flags
+    ulimits: &default-ulimits
       core:
         hard:  1000000000
         soft:  1000000000
 
   ubuntu16-osquery:
     image: "kolide/ubuntu16-osquery:${KOLIDE_OSQUERY_VERSION}"
-    volumes:
-      - ./kolide.crt:/etc/osquery/kolide.crt
-      - ./example_osquery.flags:/etc/osquery/osquery.flags
-    environment:
-      ENROLL_SECRET: "${ENROLL_SECRET}"
-    command: osqueryd --flagfile=/etc/osquery/osquery.flags
-    ulimits:
-      core:
-        hard:  1000000000
-        soft:  1000000000
+    volumes: *default-volumes
+    environment: *default-environment
+    command: *default-command
+    ulimits: *default-ulimits
 
   centos7-osquery:
     image: "kolide/centos7-osquery:${KOLIDE_OSQUERY_VERSION}"
-    volumes:
-      - ./kolide.crt:/etc/osquery/kolide.crt
-      - ./example_osquery.flags:/etc/osquery/osquery.flags
-    environment:
-      ENROLL_SECRET: "${ENROLL_SECRET}"
-    command: osqueryd --flagfile=/etc/osquery/osquery.flags
-    ulimits:
-      core:
-        hard:  1000000000
-        soft:  1000000000
+    volumes: *default-volumes
+    environment: *default-environment
+    command: *default-command
+    ulimits: *default-ulimits
 
   centos6-osquery:
     image: "kolide/centos6-osquery:${KOLIDE_OSQUERY_VERSION}"
-    volumes:
-      - ./kolide.crt:/etc/osquery/kolide.crt
-      - ./example_osquery.flags:/etc/osquery/osquery.flags
-    environment:
-      ENROLL_SECRET: "${ENROLL_SECRET}"
-    command: osqueryd --flagfile=/etc/osquery/osquery.flags
-    ulimits:
-      core:
-        hard:  1000000000
-        soft:  1000000000
+    volumes: *default-volumes
+    environment: *default-environment
+    command: *default-command
+    ulimits: *default-ulimits

--- a/tools/osquery/docker-compose.yml
+++ b/tools/osquery/docker-compose.yml
@@ -1,19 +1,25 @@
 ---
 version: '2'
 
+x-default-settings:
+  volumes: &default-volumes
+    - ./kolide.crt:/etc/osquery/kolide.crt
+    - ./example_osquery.flags:/etc/osquery/osquery.flags
+  environment: &default-environment
+    ENROLL_SECRET: "${ENROLL_SECRET:?ENROLL_SECRET must be set for server authentication}"
+  command: &default-command osqueryd --flagfile=/etc/osquery/osquery.flags --tls_hostname=${FLEET_SERVER:-host.docker.internal:8080}
+  ulimits: &default-ulimits
+    core:
+      hard:  1000000000
+      soft:  1000000000
+
 services:
   ubuntu14-osquery:
     image: "kolide/osquery:${KOLIDE_OSQUERY_VERSION}"
-    volumes: &default-volumes
-      - ./kolide.crt:/etc/osquery/kolide.crt
-      - ./example_osquery.flags:/etc/osquery/osquery.flags
-    environment: &default-environment
-      ENROLL_SECRET: "${ENROLL_SECRET:?ENROLL_SECRET must be set for server authentication}"
-    command: &default-command osqueryd --flagfile=/etc/osquery/osquery.flags
-    ulimits: &default-ulimits
-      core:
-        hard:  1000000000
-        soft:  1000000000
+    volumes: *default-volumes
+    environment: *default-environment
+    command: *default-command
+    ulimits: *default-ulimits
 
   ubuntu16-osquery:
     image: "kolide/ubuntu16-osquery:${KOLIDE_OSQUERY_VERSION}"

--- a/tools/osquery/example_osquery.flags
+++ b/tools/osquery/example_osquery.flags
@@ -4,7 +4,6 @@
 --debug
 --tls_dump=true
 
---tls_hostname=host.docker.internal:8080
 --tls_server_certs=/etc/osquery/kolide.crt
 
 --enroll_secret_env=ENROLL_SECRET


### PR DESCRIPTION
* Use YAML anchors to avoid repeating config blocks
* Use docker volumes to persist data for mysql
* Allow setting `FLEET_SERVER` (fixes #2127) when using the docker-compose file to spin up multiple osquery clients