### PR TITLE
#2283: Consistent use of constants in fleetctl

### DIFF
--- a/cmd/fleetctl/apply.go
+++ b/cmd/fleetctl/apply.go
@@ -49,58 +49,60 @@ func specGroupFromBytes(b []byte) (*specGroup, error) {
 			return nil, errors.Errorf("no spec field on %q document", s.Kind)
 		}
 
-		switch strings.ToLower(s.Kind) {
-		case "query":
+		kind := strings.ToLower(s.Kind)
+
+		switch kind {
+		case kolide.QueryKind:
 			var querySpec *kolide.QuerySpec
 			if err := yaml.Unmarshal(s.Spec, &querySpec); err != nil {
-				return nil, errors.Wrap(err, "unmarshaling query spec")
+				return nil, errors.Wrap(err, "unmarshaling "+kind+" spec")
 			}
 			specs.Queries = append(specs.Queries, querySpec)
 
-		case "pack":
+		case kolide.PackKind:
 			var packSpec *kolide.PackSpec
 			if err := yaml.Unmarshal(s.Spec, &packSpec); err != nil {
-				return nil, errors.Wrap(err, "unmarshaling pack spec")
+				return nil, errors.Wrap(err, "unmarshaling "+kind+" spec")
 			}
 			specs.Packs = append(specs.Packs, packSpec)
 
-		case "label":
+		case kolide.LabelKind:
 			var labelSpec *kolide.LabelSpec
 			if err := yaml.Unmarshal(s.Spec, &labelSpec); err != nil {
-				return nil, errors.Wrap(err, "unmarshaling label spec")
+				return nil, errors.Wrap(err, "unmarshaling "+kind+" spec")
 			}
 			specs.Labels = append(specs.Labels, labelSpec)
 
-		case "options":
+		case kolide.OptionsKind:
 			if specs.Options != nil {
 				return nil, errors.New("options defined twice in the same file")
 			}
 
 			var optionSpec *kolide.OptionsSpec
 			if err := yaml.Unmarshal(s.Spec, &optionSpec); err != nil {
-				return nil, errors.Wrap(err, "unmarshaling options spec")
+				return nil, errors.Wrap(err, "unmarshaling "+kind+" spec")
 			}
 			specs.Options = optionSpec
 
-		case "config":
+		case kolide.AppConfigKind:
 			if specs.AppConfig != nil {
 				return nil, errors.New("config defined twice in the same file")
 			}
 
 			var appConfigSpec *kolide.AppConfigPayload
 			if err := yaml.Unmarshal(s.Spec, &appConfigSpec); err != nil {
-				return nil, errors.Wrap(err, "unmarshaling config spec")
+				return nil, errors.Wrap(err, "unmarshaling "+kind+" spec")
 			}
 			specs.AppConfig = appConfigSpec
 
-		case "enroll_secret":
+		case kolide.EnrollSecretKind:
 			if specs.AppConfig != nil {
 				return nil, errors.New("enroll_secret defined twice in the same file")
 			}
 
 			var enrollSecretSpec *kolide.EnrollSecretSpec
 			if err := yaml.Unmarshal(s.Spec, &enrollSecretSpec); err != nil {
-				return nil, errors.Wrap(err, "unmarshaling enroll secret spec")
+				return nil, errors.Wrap(err, "unmarshaling "+kind+" spec")
 			}
 			specs.EnrollSecret = enrollSecretSpec
 

--- a/cmd/fleetctl/convert.go
+++ b/cmd/fleetctl/convert.go
@@ -133,8 +133,8 @@ func convertCommand() cli.Command {
 				}
 
 				meta := specMetadata{
-					Kind:    "pack",
-					Version: "v1",
+					Kind:    kolide.PackKind,
+					Version: kolide.ApiVersion,
 					Spec:    spec,
 				}
 
@@ -154,8 +154,8 @@ func convertCommand() cli.Command {
 				}
 
 				meta := specMetadata{
-					Kind:    "query",
-					Version: "v1",
+					Kind:    kolide.QueryKind,
+					Version: kolide.ApiVersion,
 					Spec:    spec,
 				}
 

--- a/cmd/fleetctl/get.go
+++ b/cmd/fleetctl/get.go
@@ -64,7 +64,7 @@ func printYaml(spec interface{}) error {
 
 func printLabel(c *cli.Context, label *kolide.LabelSpec) error {
 	spec := specGeneric{
-		Kind:    "label",
+		Kind:    kolide.LabelKind,
 		Version: kolide.ApiVersion,
 		Spec:    label,
 	}
@@ -82,7 +82,7 @@ func printLabel(c *cli.Context, label *kolide.LabelSpec) error {
 
 func printQuery(c *cli.Context, query *kolide.QuerySpec) error {
 	spec := specGeneric{
-		Kind:    "query",
+		Kind:    kolide.QueryKind,
 		Version: kolide.ApiVersion,
 		Spec:    query,
 	}
@@ -100,7 +100,7 @@ func printQuery(c *cli.Context, query *kolide.QuerySpec) error {
 
 func printPack(c *cli.Context, pack *kolide.PackSpec) error {
 	spec := specGeneric{
-		Kind:    "pack",
+		Kind:    kolide.PackKind,
 		Version: kolide.ApiVersion,
 		Spec:    pack,
 	}
@@ -118,7 +118,7 @@ func printPack(c *cli.Context, pack *kolide.PackSpec) error {
 
 func printOption(c *cli.Context, option *kolide.OptionsSpec) error {
 	spec := specGeneric{
-		Kind:    "options",
+		Kind:    kolide.OptionsKind,
 		Version: kolide.ApiVersion,
 		Spec:    option,
 	}
@@ -136,7 +136,7 @@ func printOption(c *cli.Context, option *kolide.OptionsSpec) error {
 
 func printSecret(c *cli.Context, secret *kolide.EnrollSecretSpec) error {
 	spec := specGeneric{
-		Kind:    "enroll_secret",
+		Kind:    kolide.EnrollSecretKind,
 		Version: kolide.ApiVersion,
 		Spec:    secret,
 	}
@@ -164,7 +164,7 @@ func printSecret(c *cli.Context, secret *kolide.EnrollSecretSpec) error {
 
 func printHost(c *cli.Context, host *kolide.Host) error {
 	spec := specGeneric{
-		Kind:    "host",
+		Kind:    kolide.HostKind,
 		Version: kolide.ApiVersion,
 		Spec:    host,
 	}
@@ -182,7 +182,7 @@ func printHost(c *cli.Context, host *kolide.Host) error {
 
 func printConfig(c *cli.Context, config *kolide.AppConfigPayload) error {
 	spec := specGeneric{
-		Kind:    "config",
+		Kind:    kolide.AppConfigKind,
 		Version: kolide.ApiVersion,
 		Spec:    config,
 	}

--- a/server/kolide/app.go
+++ b/server/kolide/app.go
@@ -162,6 +162,10 @@ type AppConfig struct {
 	AdditionalQueries *json.RawMessage `db:"additional_queries"`
 }
 
+const (
+	AppConfigKind = "config"
+)
+
 // ModifyAppConfigRequest contains application configuration information
 // sent from front end and used to change app config elements.
 type ModifyAppConfigRequest struct {
@@ -297,6 +301,10 @@ type EnrollSecret struct {
 	// CreatedAt is the time this enroll secret was first added.
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
 }
+
+const (
+	EnrollSecretKind = "enroll_secret"
+)
 
 // EnrollSecretSpec is the fleetctl spec type for enroll secrets.
 type EnrollSecretSpec struct {

--- a/server/kolide/hosts.go
+++ b/server/kolide/hosts.go
@@ -136,6 +136,10 @@ type Host struct {
 	EnrollSecretName          string              `json:"enroll_secret_name" db:"enroll_secret_name"`
 }
 
+const (
+	HostKind = "host"
+)
+
 // HostSummary is a structure which represents a data summary about the total
 // set of hosts in the database. This structure is returned by the HostService
 // method GetHostSummary

--- a/server/kolide/labels.go
+++ b/server/kolide/labels.go
@@ -178,6 +178,10 @@ type Label struct {
 	HostCount           int                 `json:"host_count" db:"host_count"`
 }
 
+const (
+	LabelKind = "label"
+)
+
 type LabelQueryExecution struct {
 	ID        uint
 	UpdatedAt time.Time

--- a/server/kolide/osquery_options.go
+++ b/server/kolide/osquery_options.go
@@ -31,7 +31,7 @@ type OptionsOverrides struct {
 }
 
 const (
-	OptionsKind = "Options"
+	OptionsKind = "options"
 )
 
 // OptionOverrideType is used to designate which override type a given set of

--- a/server/kolide/packs.go
+++ b/server/kolide/packs.go
@@ -130,6 +130,10 @@ type Pack struct {
 	Disabled    bool   `json:"disabled"`
 }
 
+const (
+	PackKind = "pack"
+)
+
 // PackPayload is the struct which is used to create/update packs.
 type PackPayload struct {
 	Name        *string `json:"name"`

--- a/server/kolide/queries.go
+++ b/server/kolide/queries.go
@@ -84,7 +84,7 @@ type Query struct {
 }
 
 const (
-	QueryKind = "Query"
+	QueryKind = "query"
 )
 
 type QueryObject struct {


### PR DESCRIPTION
Refactor fleetctl get & apply to use constants for spec kinds, fix #2283 