### PR TITLE
add host additional info filters

### DIFF
--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -176,6 +177,33 @@ func (d *Datastore) ListHosts(opt kolide.HostListOptions) ([]*kolide.Host, error
 	hosts := []*kolide.Host{}
 	if err := d.db.Select(&hosts, sql, params...); err != nil {
 		return nil, errors.Wrap(err, "list hosts")
+	}
+
+	// Filter additional info
+	if len(opt.AdditionalFilters) > 0 {
+		fieldsWanted := map[string]interface{}{}
+		for _, field := range opt.AdditionalFilters {
+			fieldsWanted[field] = true
+		}
+		for i, host := range hosts {
+			addInfo := map[string]interface{}{}
+			if err := json.Unmarshal(*host.Additional, &addInfo); err != nil {
+				return nil, err
+			}
+
+			for k := range addInfo {
+				if _, ok := fieldsWanted[k]; !ok {
+					delete(addInfo, k)
+				}
+			}
+			addInfoJSON := json.RawMessage{}
+			addInfoJSON, err := json.Marshal(addInfo)
+			if err != nil {
+				return nil, err
+			}
+			host.Additional = &addInfoJSON
+			hosts[i] = host
+		}
 	}
 
 	return hosts, nil

--- a/server/kolide/hosts.go
+++ b/server/kolide/hosts.go
@@ -87,7 +87,8 @@ type HostService interface {
 type HostListOptions struct {
 	ListOptions
 
-	StatusFilter HostStatus
+	AdditionalFilters []string
+	StatusFilter      HostStatus
 }
 
 type Host struct {

--- a/server/service/transport_hosts.go
+++ b/server/service/transport_hosts.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/kolide/fleet/server/kolide"
 	"github.com/pkg/errors"
@@ -47,6 +48,11 @@ func decodeListHostsRequest(ctx context.Context, r *http.Request) (interface{}, 
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	additionalInfoFiltersString := r.URL.Query().Get("additional_info_filters")
+	if additionalInfoFiltersString != "" {
+		hopt.AdditionalFilters = strings.Split(additionalInfoFiltersString, ",")
 	}
 	return listHostsRequest{ListOptions: hopt}, nil
 }


### PR DESCRIPTION
My initial take on implementing #2329. Adds a new `additional_info_filters` query param to the `/api/v1/kolide/hosts` endpoint that takes a comma delimited list of additional fields to include in the result.