### PR TITLE
Docs: Update launcher example

### DIFF
--- a/docs/infrastructure/adding-hosts-to-fleet.md
+++ b/docs/infrastructure/adding-hosts-to-fleet.md
@@ -18,12 +18,13 @@ We provide compiled releases of the launcher for all supported platforms. Those 
 
 To directly execute the launcher binary without having to mess with packages, invoke the binary with just a few flags:
 
-- `--hostname`: the hostname of the gRPC server for your environment
-- `--root_directory`: the location of the local database, pidfiles, etc.
+- `--hostname`: the hostname of Fleet (aka the gRPC server for your environment)
+- `--root_directory`: the location for osquery's local database, pidfiles, etc.
 - `--enroll_secret`: the enroll secret to authenticate hosts with Fleet
   (retrieve from Fleet UI or `fleetctl get enroll_secret`)
 
 ```
+mkdir .tmp.osquery-tmp
 ./build/launcher \
   --hostname=fleet.acme.net:443 \
   --root_directory=$(mktemp -d) \
@@ -31,6 +32,9 @@ To directly execute the launcher binary without having to mess with packages, in
 ```
 
 You may also need to define the `--insecure` and/or `--insecure_grpc` flag. If you're running Fleet locally, include `--insecure` because your TLS certificate will not be signed by a valid CA.
+
+<!-- TODO: When is --insecure_grpc needed? -->
+<!-- TODO: split docs into quickstart vs. prod, then include --insecure in quickstart for easier copy+pasting -->
 
 #### Generating packages
 

--- a/docs/infrastructure/adding-hosts-to-fleet.md
+++ b/docs/infrastructure/adding-hosts-to-fleet.md
@@ -24,10 +24,10 @@ To directly execute the launcher binary without having to mess with packages, in
   (retrieve from Fleet UI or `fleetctl get enroll_secret`)
 
 ```
-mkdir .tmp.osquery-tmp
+mkdir .osquery
 ./build/launcher \
   --hostname=fleet.acme.net:443 \
-  --root_directory=$(mktemp -d) \
+  --root_directory=.osquery \
   --enroll_secret=32IeN3QLgckHUmMD3iW40kyLdNJcGzP5
 ```
 


### PR DESCRIPTION
1. avoid creating a new dir every time to prevent duplicates of the same device showing up in Fleet
2. since the docs are Fleet-specific, disambiguate the reference to gRPC server