### PR TITLE
Fix form field focus on setup pages

### DIFF
--- a/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
@@ -25,6 +25,9 @@ class AdminDetails extends Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.currentPage && this.props.currentPage !== prevProps.currentPage) {
+      // Component has a transition duration of 300ms set in 
+      // RegistrationForm/_styles.scss. We need to wait 300ms before 
+      // calling .focus() to preserve smooth transition.
       setTimeout(() => {
         this.firstInput.input.focus();
       }, 300);

--- a/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
@@ -23,6 +23,14 @@ class AdminDetails extends Component {
     handleSubmit: PropTypes.func.isRequired,
   };
 
+  componentDidUpdate(prevProps) {
+    if (this.props.currentPage && this.props.currentPage !== prevProps.currentPage) {
+      setTimeout(() => {
+        this.firstInput.input.focus()
+      }, 300)
+    }
+  }
+
   render () {
     const { className, currentPage, fields, handleSubmit } = this.props;
     const tabIndex = currentPage ? 1 : -1;
@@ -36,6 +44,7 @@ class AdminDetails extends Component {
             placeholder="Username"
             tabIndex={tabIndex}
             autofocus={currentPage}
+            ref={(input) => { this.firstInput = input; }}
           />
           <InputFieldWithIcon
             {...fields.password}

--- a/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
@@ -26,8 +26,8 @@ class AdminDetails extends Component {
   componentDidUpdate(prevProps) {
     if (this.props.currentPage && this.props.currentPage !== prevProps.currentPage) {
       setTimeout(() => {
-        this.firstInput.input.focus()
-      }, 300)
+        this.firstInput.input.focus();
+      }, 300);
     }
   }
 

--- a/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
@@ -25,8 +25,8 @@ class AdminDetails extends Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.currentPage && this.props.currentPage !== prevProps.currentPage) {
-      // Component has a transition duration of 300ms set in 
-      // RegistrationForm/_styles.scss. We need to wait 300ms before 
+      // Component has a transition duration of 300ms set in
+      // RegistrationForm/_styles.scss. We need to wait 300ms before
       // calling .focus() to preserve smooth transition.
       setTimeout(() => {
         this.firstInput.input.focus();

--- a/frontend/components/forms/RegistrationForm/KolideDetails/KolideDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/KolideDetails/KolideDetails.jsx
@@ -20,6 +20,14 @@ class KolideDetails extends Component {
     handleSubmit: PropTypes.func.isRequired,
   };
 
+  componentDidUpdate(prevProps) {
+    if (this.props.currentPage && this.props.currentPage !== prevProps.currentPage) {
+      setTimeout(() => {
+        this.firstInput.input.focus()
+      }, 300)
+    }
+  }
+
   render () {
     const { className, currentPage, fields, handleSubmit } = this.props;
     const tabIndex = currentPage ? 1 : -1;
@@ -32,6 +40,7 @@ class KolideDetails extends Component {
             placeholder="Fleet Web Address"
             tabIndex={tabIndex}
             hint={['Don’t include ', <code key="hint">/v1</code>, ' or any other path']}
+            ref={(input) => { this.firstInput = input; }}
           />
         </div>
         <Button type="submit" variant="gradient" tabIndex={tabIndex} disabled={!currentPage}>

--- a/frontend/components/forms/RegistrationForm/KolideDetails/KolideDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/KolideDetails/KolideDetails.jsx
@@ -22,8 +22,8 @@ class KolideDetails extends Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.currentPage && this.props.currentPage !== prevProps.currentPage) {
-      // Component has a transition duration of 300ms set in 
-      // RegistrationForm/_styles.scss. We need to wait 300ms before 
+      // Component has a transition duration of 300ms set in
+      // RegistrationForm/_styles.scss. We need to wait 300ms before
       // calling .focus() to preserve smooth transition.
       setTimeout(() => {
         this.firstInput.input.focus();

--- a/frontend/components/forms/RegistrationForm/KolideDetails/KolideDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/KolideDetails/KolideDetails.jsx
@@ -23,8 +23,8 @@ class KolideDetails extends Component {
   componentDidUpdate(prevProps) {
     if (this.props.currentPage && this.props.currentPage !== prevProps.currentPage) {
       setTimeout(() => {
-        this.firstInput.input.focus()
-      }, 300)
+        this.firstInput.input.focus();
+      }, 300);
     }
   }
 

--- a/frontend/components/forms/RegistrationForm/KolideDetails/KolideDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/KolideDetails/KolideDetails.jsx
@@ -22,6 +22,9 @@ class KolideDetails extends Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.currentPage && this.props.currentPage !== prevProps.currentPage) {
+      // Component has a transition duration of 300ms set in 
+      // RegistrationForm/_styles.scss. We need to wait 300ms before 
+      // calling .focus() to preserve smooth transition.
       setTimeout(() => {
         this.firstInput.input.focus();
       }, 300);

--- a/frontend/components/forms/RegistrationForm/OrgDetails/OrgDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/OrgDetails/OrgDetails.jsx
@@ -23,8 +23,8 @@ class OrgDetails extends Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.currentPage && this.props.currentPage !== prevProps.currentPage) {
-      // Component has a transition duration of 300ms set in 
-      // RegistrationForm/_styles.scss. We need to wait 300ms before 
+      // Component has a transition duration of 300ms set in
+      // RegistrationForm/_styles.scss. We need to wait 300ms before
       // calling .focus() to preserve smooth transition.
       setTimeout(() => {
         this.firstInput.input.focus();

--- a/frontend/components/forms/RegistrationForm/OrgDetails/OrgDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/OrgDetails/OrgDetails.jsx
@@ -24,8 +24,8 @@ class OrgDetails extends Component {
   componentDidUpdate(prevProps) {
     if (this.props.currentPage && this.props.currentPage !== prevProps.currentPage) {
       setTimeout(() => {
-        this.firstInput.input.focus()
-      }, 300)
+        this.firstInput.input.focus();
+      }, 300);
     }
   }
 

--- a/frontend/components/forms/RegistrationForm/OrgDetails/OrgDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/OrgDetails/OrgDetails.jsx
@@ -21,6 +21,14 @@ class OrgDetails extends Component {
     handleSubmit: PropTypes.func.isRequired,
   };
 
+  componentDidUpdate(prevProps) {
+    if (this.props.currentPage && this.props.currentPage !== prevProps.currentPage) {
+      setTimeout(() => {
+        this.firstInput.input.focus()
+      }, 300)
+    }
+  }
+
   render () {
     const { className, currentPage, fields, handleSubmit } = this.props;
     const tabIndex = currentPage ? 1 : -1;
@@ -32,6 +40,7 @@ class OrgDetails extends Component {
             {...fields.org_name}
             placeholder="Organization Name"
             tabIndex={tabIndex}
+            ref={(input) => { this.firstInput = input; }}
           />
           <InputFieldWithIcon
             {...fields.org_logo_url}

--- a/frontend/components/forms/RegistrationForm/OrgDetails/OrgDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/OrgDetails/OrgDetails.jsx
@@ -23,6 +23,9 @@ class OrgDetails extends Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.currentPage && this.props.currentPage !== prevProps.currentPage) {
+      // Component has a transition duration of 300ms set in 
+      // RegistrationForm/_styles.scss. We need to wait 300ms before 
+      // calling .focus() to preserve smooth transition.
       setTimeout(() => {
         this.firstInput.input.focus();
       }, 300);


### PR DESCRIPTION
- Using componentDidUpdate() to check for currentPage change in setup registration form. Initially tried adding `autofocus` prop to the first `<InputFieldWithIcon />` on each page. As seen in AdminDetails page. Didn't work. I believe React only pays attention to `autofocus` when the <input> is re-rendered.

- Calling focus() on page's first input  when currentPage changes and is true. Using refs callback

- Delaying focus by 300ms using setTimeout because the `.user-registration__field-wrapper` has a transition duration of 300ms. Setting the inputs focus immediately creates a snapping movement and ruins the smooth transition.

Note: If using setTimeout isn't ideal, then another potential solution is to create an event to listen for the transition's completion.

Fixes #936 